### PR TITLE
impl portable pulp simd variants and make the other ones (that are still used) safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
  "libm",
  "num-complex",
  "num-traits",
- "pulp",
+ "pulp 0.18.22",
  "reborrow",
 ]
 
@@ -430,11 +430,13 @@ name = "gathers"
 version = "0.3.1"
 dependencies = [
  "argh",
+ "bytemuck",
  "criterion",
  "env_logger",
  "faer",
  "log",
  "num-traits",
+ "pulp 0.20.1",
  "rand",
  "rand_distr",
  "rayon",
@@ -503,7 +505,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "paste",
- "pulp",
+ "pulp 0.18.22",
  "raw-cpuid",
  "seq-macro",
  "sysctl",
@@ -837,6 +839,18 @@ name = "pulp"
 version = "0.18.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0a01a0dc67cf4558d279f0c25b0962bd08fc6dec0137699eae304103e882fe6"
+dependencies = [
+ "bytemuck",
+ "libm",
+ "num-complex",
+ "reborrow",
+]
+
+[[package]]
+name = "pulp"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e3f19bdeda2e49d16c8ae90f9615adc2298ee16974bb250d0afb705e33043f"
 dependencies = [
  "bytemuck",
  "libm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
  "faer",
  "log",
  "num-traits",
- "pulp 0.20.1",
+ "pulp 0.21.0",
  "rand",
  "rand_distr",
  "rayon",
@@ -848,11 +848,12 @@ dependencies = [
 
 [[package]]
 name = "pulp"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e3f19bdeda2e49d16c8ae90f9615adc2298ee16974bb250d0afb705e33043f"
+checksum = "04badad8b0d8851e02f6aac34b8b100c4e6ea0f9b375b3e2df5a89d7453880a0"
 dependencies = [
  "bytemuck",
+ "cfg-if",
  "libm",
  "num-complex",
  "reborrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,12 @@ categories = ["algorithms", "science"]
 
 [dependencies]
 argh = "0.1.12"
+bytemuck = "1.20.0"
 env_logger = "0.11.5"
 faer = { version = "0.19.4", default-features = false, features = ["std"] }
 log = "0.4.22"
 num-traits = "0.2.19"
+pulp = "0.20.1"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 rayon = "1.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ env_logger = "0.11.5"
 faer = { version = "0.19.4", default-features = false, features = ["std"] }
 log = "0.4.22"
 num-traits = "0.2.19"
-pulp = "0.20.1"
+pulp = "0.21.0"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 rayon = "1.10.0"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,7 +2,8 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use gathers::distance::{
     native_argmin, native_dot_produce, native_l2_norm, native_squared_euclidean,
 };
-use gathers::simd::{argmin, dot_product, l2_norm, l2_squared_distance};
+use gathers::simd::{self, argmin, dot_product, l2_norm, l2_squared_distance};
+use pulp::x86::V3;
 use rand::{thread_rng, Rng};
 
 pub fn l2_norm_benchmark(c: &mut Criterion) {
@@ -18,6 +19,11 @@ pub fn l2_norm_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("simd", dim), &x, |b, input| {
             b.iter(|| unsafe { l2_norm(&input) })
         });
+        if let Some(simd) = V3::try_new() {
+            group.bench_with_input(BenchmarkId::new("pulp", dim), &x, |b, input| {
+                b.iter(|| simd::pulp::l2_norm(simd, &input))
+            });
+        }
     }
     group.finish();
 }
@@ -35,6 +41,11 @@ pub fn argmin_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("simd", dim), &x, |b, input| {
             b.iter(|| unsafe { argmin(&input) })
         });
+        if let Some(simd) = V3::try_new() {
+            group.bench_with_input(BenchmarkId::new("pulp", dim), &x, |b, input| {
+                b.iter(|| simd::pulp::argmin(simd, &input))
+            });
+        }
     }
 }
 
@@ -54,6 +65,11 @@ pub fn l2_distance_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("simd", dim), &(&lhs, &rhs), |b, input| {
             b.iter(|| unsafe { l2_squared_distance(&input.0, &input.1) })
         });
+        if let Some(simd) = V3::try_new() {
+            group.bench_with_input(BenchmarkId::new("pulp", dim), &(&lhs, &rhs), |b, input| {
+                b.iter(|| simd::pulp::l2_squared_distance(simd, &input.0, &input.1))
+            });
+        }
     }
     group.finish();
 }
@@ -74,6 +90,11 @@ pub fn ip_distance_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("simd", dim), &(&lhs, &rhs), |b, input| {
             b.iter(|| unsafe { dot_product(&input.0, &input.1) })
         });
+        if let Some(simd) = V3::try_new() {
+            group.bench_with_input(BenchmarkId::new("pulp", dim), &(&lhs, &rhs), |b, input| {
+                b.iter(|| simd::pulp::dot_product(simd, &input.0, &input.1))
+            });
+        }
     }
     group.finish();
 }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
  "libm",
  "num-complex",
  "num-traits",
- "pulp",
+ "pulp 0.18.22",
  "reborrow",
 ]
 
@@ -324,10 +324,12 @@ name = "gathers"
 version = "0.3.1"
 dependencies = [
  "argh",
+ "bytemuck",
  "env_logger",
  "faer",
  "log",
  "num-traits",
+ "pulp 0.21.0",
  "rand",
  "rand_distr",
  "rayon",
@@ -335,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "gatherspy"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "gathers",
  "numpy",
@@ -405,7 +407,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "paste",
- "pulp",
+ "pulp 0.18.22",
  "raw-cpuid",
  "seq-macro",
  "sysctl",
@@ -745,6 +747,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0a01a0dc67cf4558d279f0c25b0962bd08fc6dec0137699eae304103e882fe6"
 dependencies = [
  "bytemuck",
+ "libm",
+ "num-complex",
+ "reborrow",
+]
+
+[[package]]
+name = "pulp"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04badad8b0d8851e02f6aac34b8b100c4e6ea0f9b375b3e2df5a89d7453880a0"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
  "libm",
  "num-complex",
  "reborrow",

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -20,18 +20,21 @@ pub fn native_l2_norm(vec: &[f32]) -> f32 {
 /// Compute the L2 norm of the vector.
 #[inline]
 pub fn l2_norm(vec: &[f32]) -> f32 {
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    {
-        if is_x86_feature_detected!("avx2") {
-            unsafe { crate::simd::l2_norm(vec) }
-        } else {
-            native_l2_norm(vec)
+    struct Impl<'a> {
+        vec: &'a [f32],
+    }
+
+    impl pulp::WithSimd for Impl<'_> {
+        type Output = f32;
+
+        #[inline(always)]
+        fn with_simd<S: pulp::Simd>(self, simd: S) -> Self::Output {
+            let Self { vec } = self;
+            crate::simd::pulp::l2_norm(simd, vec)
         }
     }
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
-    {
-        native_l2_norm(vec)
-    }
+
+    pulp::Arch::new().dispatch(Impl { vec })
 }
 
 /// Native implementation of squared euclidean distance.
@@ -46,18 +49,22 @@ pub fn native_squared_euclidean(lhs: &[f32], rhs: &[f32]) -> f32 {
 /// Compute the squared Euclidean distance between two vectors.
 #[inline]
 pub fn squared_euclidean(lhs: &[f32], rhs: &[f32]) -> f32 {
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    {
-        if is_x86_feature_detected!("avx2") {
-            unsafe { crate::simd::l2_squared_distance(lhs, rhs) }
-        } else {
-            native_squared_euclidean(lhs, rhs)
+    struct Impl<'a> {
+        lhs: &'a [f32],
+        rhs: &'a [f32],
+    }
+
+    impl pulp::WithSimd for Impl<'_> {
+        type Output = f32;
+
+        #[inline(always)]
+        fn with_simd<S: pulp::Simd>(self, simd: S) -> Self::Output {
+            let Self { lhs, rhs } = self;
+            crate::simd::pulp::l2_squared_distance(simd, lhs, rhs)
         }
     }
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
-    {
-        native_squared_euclidean(lhs, rhs)
-    }
+
+    pulp::Arch::new().dispatch(Impl { lhs, rhs })
 }
 
 /// Native implementation of negative dot product.
@@ -72,18 +79,22 @@ pub fn native_dot_produce(lhs: &[f32], rhs: &[f32]) -> f32 {
 /// Compute the negative dot product between two vectors.
 #[inline]
 pub fn neg_dot_product(lhs: &[f32], rhs: &[f32]) -> f32 {
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    {
-        if is_x86_feature_detected!("avx2") {
-            unsafe { -crate::simd::dot_product(lhs, rhs) }
-        } else {
-            -native_dot_produce(lhs, rhs)
+    struct Impl<'a> {
+        lhs: &'a [f32],
+        rhs: &'a [f32],
+    }
+
+    impl pulp::WithSimd for Impl<'_> {
+        type Output = f32;
+
+        #[inline(always)]
+        fn with_simd<S: pulp::Simd>(self, simd: S) -> Self::Output {
+            let Self { lhs, rhs } = self;
+            -crate::simd::pulp::dot_product(simd, lhs, rhs)
         }
     }
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
-    {
-        -native_dot_produce(lhs, rhs)
-    }
+
+    pulp::Arch::new().dispatch(Impl { lhs, rhs })
 }
 
 /// Native implementation of argmin.
@@ -103,18 +114,21 @@ pub fn native_argmin(vec: &[f32]) -> usize {
 /// Find the index of the minimum value in the vector.
 #[inline]
 pub fn argmin(vec: &[f32]) -> usize {
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    {
-        if is_x86_feature_detected!("avx2") {
-            unsafe { crate::simd::argmin(vec) }
-        } else {
-            native_argmin(vec)
+    struct Impl<'a> {
+        vec: &'a [f32],
+    }
+
+    impl pulp::WithSimd for Impl<'_> {
+        type Output = usize;
+
+        #[inline(always)]
+        fn with_simd<S: pulp::Simd>(self, simd: S) -> Self::Output {
+            let Self { vec } = self;
+            crate::simd::pulp::argmin(simd, vec)
         }
     }
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
-    {
-        native_argmin(vec)
-    }
+
+    pulp::Arch::new().dispatch(Impl { vec })
 }
 
 #[cfg(test)]

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -8,6 +8,7 @@ pub mod pulp;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 ::pulp::simd_type!(
+    #[allow(clippy::too_many_arguments)]
     pub(crate) struct Avx2 {
         sse2: "sse2",
         avx: "avx",

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -1,6 +1,19 @@
 //! Accelerate with SIMD.
 
+use core::iter;
+
 use crate::rabitq::THETA_LOG_DIM;
+
+pub mod pulp;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+::pulp::simd_type!(
+    pub(crate) struct Avx2 {
+        sse2: "sse2",
+        avx: "avx",
+        avx2: "avx2",
+    }
+);
 
 /// Compute the squared Euclidean distance between two vectors.
 ///
@@ -320,176 +333,206 @@ pub unsafe fn min_max_residual(res: &mut [f32], x: &[f32], y: &[f32]) -> (f32, f
 ///
 /// This function doesn't need `bias` because it *round* the f32 to u32 instead of *floor*.
 ///
-/// # Safety
+/// # Panics
 ///
-/// This function is marked unsafe because it requires the AVX intrinsics.
+/// This function panics if the `sse2`, `avx` and `avx2` target features are not available.
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-#[target_feature(enable = "avx,avx2")]
 #[inline]
-pub unsafe fn scalar_quantize(
+pub fn scalar_quantize(
     quantized: &mut [u8],
     vec: &[f32],
     lower_bound: f32,
     multiplier: f32,
 ) -> u32 {
-    #[cfg(target_arch = "x86")]
-    use std::arch::x86::*;
-    #[cfg(target_arch = "x86_64")]
-    use std::arch::x86_64::*;
+    use ::pulp;
 
-    let mut quantize_ptr = quantized.as_mut_ptr() as *mut u64;
+    let simd = Avx2::try_new().unwrap();
+    let avx = simd.avx;
+    let avx2 = simd.avx2;
 
-    let lower = _mm256_set1_ps(lower_bound);
-    let scalar = _mm256_set1_ps(multiplier);
-    let mut sum256 = _mm256_setzero_si256();
-    let mask = _mm256_setr_epi8(
-        0, 4, 8, 12, -1, -1, -1, -1, //
-        -1, -1, -1, -1, -1, -1, -1, -1, //
-        0, 4, 8, 12, -1, -1, -1, -1, //
-        -1, -1, -1, -1, -1, -1, -1, -1,
-    );
-    let length = vec.len();
-    let rest = length & 0b111;
-    let mut vec_ptr = vec.as_ptr();
-    let mut quantize8xi32;
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            let (quantize, quantize_tail) = pulp::as_arrays_mut::<8, _>(quantized);
 
-    for _ in 0..(length / 8) {
-        let v = _mm256_loadu_ps(vec_ptr);
-        // `_mm256_cvtps_epi32` is *round* instead of *floor*, so we don't need the bias here
-        quantize8xi32 = _mm256_cvtps_epi32(_mm256_mul_ps(_mm256_sub_ps(v, lower), scalar));
-        sum256 = _mm256_add_epi32(sum256, quantize8xi32);
-        // extract the lower 8 bits of each 32-bit integer and save them to [0..32] and [128..160]
-        let shuffled = _mm256_shuffle_epi8(quantize8xi32, mask);
-        quantize_ptr.write(
-            (_mm256_extract_epi32(shuffled, 0) as u64)
-                | ((_mm256_extract_epi32(shuffled, 4) as u64) << 32),
-        );
-        quantize_ptr = quantize_ptr.add(1);
-        vec_ptr = vec_ptr.add(8);
-    }
+            let lower = avx._mm256_set1_ps(lower_bound);
+            let scalar = avx._mm256_set1_ps(multiplier);
+            let mut sum256 = avx._mm256_setzero_si256();
+            let mask = avx._mm256_setr_epi8(
+                0, 4, 8, 12, -1, -1, -1, -1, //
+                -1, -1, -1, -1, -1, -1, -1, -1, //
+                0, 4, 8, 12, -1, -1, -1, -1, //
+                -1, -1, -1, -1, -1, -1, -1, -1,
+            );
+            let (vec, vec_tail) = pulp::as_arrays::<8, _>(vec);
+            let mut quantize8xi32;
 
-    // Compute the sum of the quantized values
-    // add [4..7] to [0..3]
-    let mut combined = _mm256_add_epi32(sum256, _mm256_permute2f128_si256(sum256, sum256, 1));
-    // combine [0..3] to [0..1]
-    combined = _mm256_hadd_epi32(combined, combined);
-    // combine [0..1] to [0]
-    combined = _mm256_hadd_epi32(combined, combined);
-    let mut sum = _mm256_cvtsi256_si32(combined) as u32;
+            for (q, &v) in iter::zip(quantize, vec) {
+                let v = pulp::cast(v);
+                // `avx._mm256_cvtps_epi32` is *round* instead of *floor*, so we don't need the bias here
+                quantize8xi32 =
+                    avx._mm256_cvtps_epi32(avx._mm256_mul_ps(avx._mm256_sub_ps(v, lower), scalar));
+                sum256 = avx2._mm256_add_epi32(sum256, quantize8xi32);
+                // extract the lower 8 bits of each 32-bit integer and save them to [0..32] and [128..160]
+                let shuffled = avx2._mm256_shuffle_epi8(quantize8xi32, mask);
+                *q = pulp::cast::<u64, _>(
+                    (avx2._mm256_extract_epi32::<0>(shuffled) as u64)
+                        | ((avx2._mm256_extract_epi32::<4>(shuffled) as u64) << 32),
+                );
+            }
 
-    for i in 0..rest {
-        // this should be safe as it's a scalar quantization
-        let q = ((*vec_ptr - lower_bound) * multiplier)
-            .round()
-            .to_int_unchecked::<u8>();
-        quantized[length - rest + i] = q;
-        sum += q as u32;
-        vec_ptr = vec_ptr.add(1);
-    }
+            // Compute the sum of the quantized values
+            // add [4..7] to [0..3]
+            let mut combined =
+                avx2._mm256_add_epi32(sum256, avx._mm256_permute2f128_si256::<1>(sum256, sum256));
+            // combine [0..3] to [0..1]
+            combined = avx2._mm256_hadd_epi32(combined, combined);
+            // combine [0..1] to [0]
+            combined = avx2._mm256_hadd_epi32(combined, combined);
+            let mut sum = avx2._mm256_cvtsi256_si32(combined) as u32;
 
-    sum
+            for (q, &v) in iter::zip(quantize_tail, vec_tail) {
+                *q = ((v - lower_bound) * multiplier).round() as u8;
+                sum += *q as u32;
+            }
+
+            sum
+        },
+    )
 }
 
 /// Convert an [u8] to 4x binary vector stored as u64.
 ///
-/// # Safety
+/// # Panics
 ///
-/// This function is marked unsafe because it requires the AVX intrinsics.
+/// This function panics if the `sse2`, `avx` and `avx2` target features are not available.
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-#[target_feature(enable = "avx,avx2")]
 #[inline]
-pub unsafe fn vector_binarize_query(vec: &[u8], binary: &mut [u64]) {
-    #[cfg(target_arch = "x86")]
-    use std::arch::x86::*;
-    #[cfg(target_arch = "x86_64")]
-    use std::arch::x86_64::*;
+pub fn vector_binarize_query(vec: &[u8], binary: &mut [u64]) {
+    use ::pulp;
 
-    let length = vec.len();
-    let mut ptr = vec.as_ptr() as *const __m256i;
+    let simd = Avx2::try_new().unwrap();
+    let avx2 = simd.avx2;
 
-    for i in (0..length).step_by(32) {
-        // since it's not guaranteed that the vec is fully-aligned
-        let mut v = _mm256_loadu_si256(ptr);
-        ptr = ptr.add(1);
-        // only the lower 4 bits are useful due to the 4-bit scalar quantization
-        v = _mm256_slli_epi32(v, 4);
-        for j in 0..THETA_LOG_DIM {
-            // extract the MSB of each u8
-            let mask = (_mm256_movemask_epi8(v) as u32) as u64;
-            // (opposite version) let shift = if (i / 32) % 2 == 0 { 32 } else { 0 };
-            let shift = i & 32;
-            binary[(3 - j) * (length >> 6) + (i >> 6)] |= mask << shift;
-            v = _mm256_slli_epi32(v, 1);
-        }
-    }
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            assert_eq!(THETA_LOG_DIM, 4);
+            assert_eq!(vec.len() % 64, 0);
+            assert_eq!(binary.len() % 4, 0);
+            assert_eq!(vec.len() / 64, binary.len() / 4);
+
+            let vec = pulp::as_arrays::<64, _>(vec).0;
+
+            let n4 = binary.len() / 4;
+            let (binary0, binary) = binary.split_at_mut(n4);
+            let (binary1, binary) = binary.split_at_mut(n4);
+            let (binary2, binary) = binary.split_at_mut(n4);
+            let (binary3, binary) = binary.split_at_mut(n4);
+            _ = binary;
+
+            for (((b0, b1), (b2, b3)), &v) in iter::zip(
+                iter::zip(iter::zip(binary0, binary1), iter::zip(binary2, binary3)),
+                vec,
+            ) {
+                let mut v: [_; 2] = pulp::cast(v);
+
+                // only the lower 4 bits are useful due to the 4-bit scalar quantization
+                v[0] = avx2._mm256_slli_epi32::<4>(v[0]);
+                v[1] = avx2._mm256_slli_epi32::<4>(v[1]);
+
+                for b in [b3, b2, b1, b0] {
+                    // extract the MSB of each u8
+                    let mask0 = (avx2._mm256_movemask_epi8(v[0]) as u32) as u64;
+                    let mask1 = (avx2._mm256_movemask_epi8(v[1]) as u32) as u64;
+
+                    *b |= mask0 | (mask1 << 32);
+
+                    // move the next bit to the MSB
+                    v[0] = avx2._mm256_slli_epi32::<1>(v[0]);
+                    v[1] = avx2._mm256_slli_epi32::<1>(v[1]);
+                }
+            }
+        },
+    )
 }
 
 /// Compute the binary dot product of two vectors.
 ///
 /// Refer to: <https://github.com/komrad36/popcount>
 ///
-/// # Safety
+/// # Panics
 ///
-/// This function is marked unsafe because it requires the AVX2 intrinsics.
+/// This function panics if the `sse2`, `avx` and `avx2` target features are not available.
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-#[target_feature(enable = "sse2,avx,avx2")]
 #[inline]
-pub unsafe fn binary_dot_product(lhs: &[u64], rhs: &[u64]) -> u32 {
+pub fn binary_dot_product(lhs: &[u64], rhs: &[u64]) -> u32 {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::*;
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::*;
 
-    let mut sum = 0;
-    let length = lhs.len() / 4;
-    if length == 0 {
-        for i in 0..lhs.len() {
-            sum += (lhs[i] & rhs[i]).count_ones();
-        }
-        return sum;
-    }
-    let rest = lhs.len() & 0b11;
-    for i in 0..rest {
-        sum += (lhs[4 * length + i] & rhs[4 * length + i]).count_ones();
-    }
+    use ::pulp;
+    use pulp::cast;
 
-    #[inline]
-    unsafe fn mm256_popcnt_epi64(x: __m256i) -> __m256i {
-        let lookup_table = _mm256_setr_epi8(
-            0, 1, 1, 2, 1, 2, 2, 3, // 0-7
-            1, 2, 2, 3, 2, 3, 3, 4, // 8-15
-            0, 1, 1, 2, 1, 2, 2, 3, // 16-23
-            1, 2, 2, 3, 2, 3, 3, 4, // 24-31
-        );
-        let mask = _mm256_set1_epi8(15);
-        let zero = _mm256_setzero_si256();
+    let simd @ Avx2 { avx, avx2, sse2 } = Avx2::try_new().unwrap();
 
-        let mut low = _mm256_and_si256(x, mask);
-        let mut high = _mm256_and_si256(_mm256_srli_epi64(x, 4), mask);
-        low = _mm256_shuffle_epi8(lookup_table, low);
-        high = _mm256_shuffle_epi8(lookup_table, high);
-        _mm256_sad_epu8(_mm256_add_epi8(low, high), zero)
-    }
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            let mut sum = 0;
+            let length = lhs.len() / 4;
+            if length == 0 {
+                for i in 0..lhs.len() {
+                    sum += (lhs[i] & rhs[i]).count_ones();
+                }
+                return sum;
+            }
+            let rest = lhs.len() & 0b11;
+            for i in 0..rest {
+                sum += (lhs[4 * length + i] & rhs[4 * length + i]).count_ones();
+            }
 
-    let mut sum256 = _mm256_setzero_si256();
-    let mut x_ptr = lhs.as_ptr() as *const __m256i;
-    let mut y_ptr = rhs.as_ptr() as *const __m256i;
+            #[inline(always)]
+            fn mm256_popcnt_epi64(simd: Avx2, x: __m256i) -> __m256i {
+                let Avx2 { avx, avx2, .. } = simd;
 
-    for _ in 0..length {
-        let x256 = _mm256_loadu_si256(x_ptr);
-        let y256 = _mm256_loadu_si256(y_ptr);
-        let and = _mm256_and_si256(x256, y256);
-        sum256 = _mm256_add_epi64(sum256, mm256_popcnt_epi64(and));
-        x_ptr = x_ptr.add(1);
-        y_ptr = y_ptr.add(1);
-    }
+                let lookup_table = avx._mm256_setr_epi8(
+                    0, 1, 1, 2, 1, 2, 2, 3, // 0-7
+                    1, 2, 2, 3, 2, 3, 3, 4, // 8-15
+                    0, 1, 1, 2, 1, 2, 2, 3, // 16-23
+                    1, 2, 2, 3, 2, 3, 3, 4, // 24-31
+                );
+                let mask = avx._mm256_set1_epi8(15);
+                let zero = avx._mm256_setzero_si256();
 
-    let xa = _mm_add_epi64(
-        _mm256_castsi256_si128(sum256),
-        _mm256_extracti128_si256(sum256, 1),
-    );
-    // this assumes the sum is less than 2^31, which should be true for most cases
-    sum += _mm_cvtsi128_si32(_mm_add_epi64(xa, _mm_shuffle_epi32(xa, 78))) as u32;
+                let mut low = avx2._mm256_and_si256(x, mask);
+                let mut high = avx2._mm256_and_si256(avx2._mm256_srli_epi64::<4>(x), mask);
+                low = avx2._mm256_shuffle_epi8(lookup_table, low);
+                high = avx2._mm256_shuffle_epi8(lookup_table, high);
+                avx2._mm256_sad_epu8(avx2._mm256_add_epi8(low, high), zero)
+            }
 
-    sum
+            let mut sum256 = avx._mm256_setzero_si256();
+            let x_ptr = pulp::as_arrays::<4, _>(lhs).0;
+            let y_ptr = pulp::as_arrays::<4, _>(rhs).0;
+
+            for (&x, &y) in iter::zip(x_ptr, y_ptr) {
+                let x256 = cast(x);
+                let y256 = cast(y);
+                let and = avx2._mm256_and_si256(x256, y256);
+                sum256 = avx2._mm256_add_epi64(sum256, mm256_popcnt_epi64(simd, and));
+            }
+
+            let xa = sse2._mm_add_epi64(
+                avx._mm256_castsi256_si128(sum256),
+                avx2._mm256_extracti128_si256::<1>(sum256),
+            );
+            // this assumes the sum is less than 2^31, which should be true for most cases
+            sum += sse2._mm_cvtsi128_si32(sse2._mm_add_epi64(xa, sse2._mm_shuffle_epi32::<78>(xa)))
+                as u32;
+
+            sum
+        },
+    )
 }

--- a/src/simd/pulp.rs
+++ b/src/simd/pulp.rs
@@ -248,6 +248,9 @@ pub fn min_max_residual<S: Simd>(simd: S, res: &mut [f32], x: &[f32], y: &[f32])
                 max0 = simd.max_f32s(max0, diff);
             }
 
+            min0 = simd.min_f32s(min0, min1);
+            max0 = simd.max_f32s(max0, max1);
+
             {
                 let m = simd.mask_between_m32s(0, x_tail.len() as u32).mask();
 

--- a/src/simd/pulp.rs
+++ b/src/simd/pulp.rs
@@ -1,0 +1,264 @@
+//! SIMD implementation with `pulp`
+
+use core::iter;
+
+use pulp::{as_arrays, as_arrays_mut, Simd};
+
+#[inline(always)]
+fn abs2_add<S: Simd>(simd: S, x: S::f32s, acc: S::f32s) -> S::f32s {
+    simd.mul_add_f32s(x, x, acc)
+}
+
+/// Compute the squared Euclidean distance between two vectors.
+///
+/// Code refers to <https://github.com/nmslib/hnswlib/blob/master/hnswlib/space_l2.h>
+#[inline]
+pub fn l2_squared_distance<S: Simd>(simd: S, lhs: &[f32], rhs: &[f32]) -> f32 {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            assert_eq!(lhs.len(), rhs.len());
+
+            let (lhs, lhs_tail) = S::as_simd_f32s(lhs);
+            let (rhs, rhs_tail) = S::as_simd_f32s(rhs);
+
+            let (lhs2, lhs1) = as_arrays::<2, _>(lhs);
+            let (rhs2, rhs1) = as_arrays::<2, _>(rhs);
+
+            let mut sum0 = simd.splat_f32s(0.0);
+            let mut sum1 = simd.splat_f32s(0.0);
+
+            for (&[l0, l1], &[r0, r1]) in iter::zip(lhs2, rhs2) {
+                sum0 = abs2_add(simd, simd.sub_f32s(l0, r0), sum0);
+                sum1 = abs2_add(simd, simd.sub_f32s(l1, r1), sum1);
+            }
+
+            for (&l0, &r0) in iter::zip(lhs1, rhs1) {
+                sum0 = abs2_add(simd, simd.sub_f32s(l0, r0), sum0);
+            }
+            {
+                let l0 = simd.partial_load_f32s(lhs_tail);
+                let r0 = simd.partial_load_f32s(rhs_tail);
+
+                sum0 = abs2_add(simd, simd.sub_f32s(l0, r0), sum0);
+            }
+
+            simd.reduce_sum_f32s(simd.add_f32s(sum0, sum1))
+        },
+    )
+}
+
+/// Compute the negative dot product distance between two vectors.
+#[inline]
+pub fn dot_product<S: Simd>(simd: S, lhs: &[f32], rhs: &[f32]) -> f32 {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            assert_eq!(lhs.len(), rhs.len());
+
+            let (lhs, lhs_tail) = S::as_simd_f32s(lhs);
+            let (rhs, rhs_tail) = S::as_simd_f32s(rhs);
+
+            let (lhs2, lhs1) = as_arrays::<2, _>(lhs);
+            let (rhs2, rhs1) = as_arrays::<2, _>(rhs);
+
+            let mut sum0 = simd.splat_f32s(0.0);
+            let mut sum1 = simd.splat_f32s(0.0);
+
+            for (&[l0, l1], &[r0, r1]) in iter::zip(lhs2, rhs2) {
+                sum0 = simd.mul_add_f32s(l0, r0, sum0);
+                sum1 = simd.mul_add_f32s(l1, r1, sum1);
+            }
+
+            for (&l0, &r0) in iter::zip(lhs1, rhs1) {
+                sum0 = simd.mul_add_f32s(l0, r0, sum0);
+            }
+            {
+                let l0 = simd.partial_load_f32s(lhs_tail);
+                let r0 = simd.partial_load_f32s(rhs_tail);
+
+                sum0 = simd.mul_add_f32s(l0, r0, sum0);
+            }
+
+            simd.reduce_sum_f32s(simd.add_f32s(sum0, sum1))
+        },
+    )
+}
+
+/// Compute the L2 norm of the vector.
+///
+/// Doesn't handle overflow/underflow for inputs outside of the [MIN_EXP/2, MAX_EXP/2] range.
+#[inline]
+pub fn l2_norm<S: Simd>(simd: S, vec: &[f32]) -> f32 {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            let (vec, vec_tail) = S::as_simd_f32s(vec);
+            let (vec2, vec1) = as_arrays::<2, _>(vec);
+
+            let mut sum0 = simd.splat_f32s(0.0);
+            let mut sum1 = simd.splat_f32s(0.0);
+
+            for &[v0, v1] in vec2 {
+                sum0 = abs2_add(simd, v0, sum0);
+                sum1 = abs2_add(simd, v1, sum1);
+            }
+
+            for &v0 in vec1 {
+                sum0 = abs2_add(simd, v0, sum0);
+            }
+            {
+                let v0 = simd.partial_load_f32s(vec_tail);
+                sum0 = abs2_add(simd, v0, sum0);
+            }
+
+            simd.reduce_sum_f32s(simd.add_f32s(sum0, sum1)).sqrt()
+        },
+    )
+}
+
+/// Find the index of the minimum value in the vector.
+#[inline]
+pub fn argmin<S: Simd>(simd: S, vec: &[f32]) -> usize {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            let (vec, vec_tail) = S::as_simd_f32s(vec);
+            let (vec4, vec1) = as_arrays::<4, _>(vec);
+
+            let inc = simd.splat_u32s(S::U32_LANES as u32);
+            let infty = simd.splat_f32s(f32::INFINITY);
+
+            let mut min0 = infty;
+            let mut min1 = infty;
+            let mut min2 = infty;
+            let mut min3 = infty;
+
+            let mut min_idx0 = simd.splat_u32s(0);
+            let mut min_idx1 = simd.splat_u32s(0);
+            let mut min_idx2 = simd.splat_u32s(0);
+            let mut min_idx3 = simd.splat_u32s(0);
+
+            let mut idx = pulp::cast_lossy([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+            for &[v0, v1, v2, v3] in vec4 {
+                let less = simd.less_than_f32s(v0, min0);
+                min0 = simd.select_f32s_m32s(less, v0, min0);
+                min_idx0 = simd.select_u32s_m32s(less, idx, min_idx0);
+                idx = simd.add_u32s(idx, inc);
+
+                let less = simd.less_than_f32s(v1, min1);
+                min1 = simd.select_f32s_m32s(less, v1, min1);
+                min_idx1 = simd.select_u32s_m32s(less, idx, min_idx1);
+                idx = simd.add_u32s(idx, inc);
+
+                let less = simd.less_than_f32s(v2, min2);
+                min2 = simd.select_f32s_m32s(less, v2, min2);
+                min_idx2 = simd.select_u32s_m32s(less, idx, min_idx2);
+                idx = simd.add_u32s(idx, inc);
+
+                let less = simd.less_than_f32s(v3, min3);
+                min3 = simd.select_f32s_m32s(less, v3, min3);
+                min_idx3 = simd.select_u32s_m32s(less, idx, min_idx3);
+                idx = simd.add_u32s(idx, inc);
+            }
+
+            for &v0 in vec1 {
+                let less = simd.less_than_f32s(v0, min0);
+                min0 = simd.select_f32s_m32s(less, v0, min0);
+                min_idx0 = simd.select_u32s_m32s(less, idx, min_idx0);
+
+                idx = simd.add_u32s(idx, inc);
+            }
+
+            {
+                let m = simd.mask_between_m32s(0, vec_tail.len() as u32).mask();
+
+                let v0 = simd.partial_load_f32s(vec_tail);
+                let v0 = simd.select_f32s_m32s(m, v0, infty);
+
+                let less = simd.less_than_f32s(v0, min0);
+                min0 = simd.select_f32s_m32s(less, v0, min0);
+                min_idx0 = simd.select_u32s_m32s(less, idx, min_idx0);
+            }
+
+            let less = simd.less_than_f32s(min0, min2);
+            min0 = simd.select_f32s_m32s(less, min0, min2);
+            min_idx0 = simd.select_u32s_m32s(less, min_idx0, min_idx2);
+
+            let less = simd.less_than_f32s(min1, min3);
+            min1 = simd.select_f32s_m32s(less, min1, min3);
+            min_idx1 = simd.select_u32s_m32s(less, min_idx1, min_idx3);
+
+            let less = simd.less_than_f32s(min0, min1);
+            min0 = simd.select_f32s_m32s(less, min0, min1);
+            min_idx0 = simd.select_u32s_m32s(less, min_idx0, min_idx1);
+
+            let min = simd.reduce_min_f32s(min0);
+            let is_min = simd.equal_f32s(min0, simd.splat_f32s(min));
+            let pos = simd.first_true_m32s(is_min);
+            let min_idx = bytemuck::cast_slice::<S::u32s, u32>(core::slice::from_ref(&min_idx0));
+
+            if pos < S::U32_LANES {
+                min_idx[pos] as usize
+            } else {
+                0
+            }
+        },
+    )
+}
+
+/// Compute the min and max value of a vector.
+#[inline]
+pub fn min_max_residual<S: Simd>(simd: S, res: &mut [f32], x: &[f32], y: &[f32]) -> (f32, f32) {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            let (res, res_tail) = S::as_mut_simd_f32s(res);
+            let (x, x_tail) = S::as_simd_f32s(x);
+            let (y, y_tail) = S::as_simd_f32s(y);
+
+            let (res2, res1) = as_arrays_mut::<2, _>(res);
+            let (x2, x1) = as_arrays::<2, _>(x);
+            let (y2, y1) = as_arrays::<2, _>(y);
+
+            let infty = f32::INFINITY;
+
+            let mut min0 = simd.splat_f32s(infty);
+            let mut min1 = simd.splat_f32s(infty);
+            let mut max0 = simd.splat_f32s(-infty);
+            let mut max1 = simd.splat_f32s(-infty);
+
+            for ([res0, res1], (&[x0, x1], &[y0, y1])) in iter::zip(res2, iter::zip(x2, y2)) {
+                let diff = simd.sub_f32s(x0, y0);
+                *res0 = diff;
+                min0 = simd.min_f32s(min0, diff);
+                max0 = simd.max_f32s(max0, diff);
+
+                let diff = simd.sub_f32s(x1, y1);
+                *res1 = diff;
+                min1 = simd.min_f32s(min1, diff);
+                max1 = simd.max_f32s(max1, diff);
+            }
+
+            for (res0, (&x0, &y0)) in iter::zip(res1, iter::zip(x1, y1)) {
+                let diff = simd.sub_f32s(x0, y0);
+                *res0 = diff;
+                min0 = simd.min_f32s(min0, diff);
+                max0 = simd.max_f32s(max0, diff);
+            }
+
+            {
+                let x0 = simd.partial_load_f32s(x_tail);
+                let y0 = simd.partial_load_f32s(y_tail);
+
+                let diff = simd.sub_f32s(x0, y0);
+                simd.partial_store_f32s(res_tail, diff);
+
+                min0 = simd.min_f32s(min0, diff);
+                max0 = simd.max_f32s(max0, diff);
+            }
+
+            (simd.reduce_min_f32s(min0), simd.reduce_max_f32s(max0))
+        },
+    )
+}


### PR DESCRIPTION
pretty much every benchmark is faster with the new impl, with the exception of the smallest size (n = 64)