### PR TITLE
perf: accelerate k-means on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -93,6 +93,26 @@ name = "bytemuck"
 version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
@@ -226,6 +246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "defer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
+
+[[package]]
 name = "dyn-stack"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +265,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "env_filter"
@@ -276,7 +314,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -287,7 +325,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -307,6 +345,7 @@ dependencies = [
  "nano-gemm",
  "num-complex",
  "num-traits",
+ "private-gemm-x86",
  "pulp",
  "reborrow",
 ]
@@ -319,7 +358,7 @@ checksum = "9d0a255d1442b5825c61812a7eafda9034ec53d969c98555251085e148428e6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -368,6 +407,7 @@ dependencies = [
  "gemm-c32",
  "gemm-c64",
  "gemm-common",
+ "gemm-f16",
  "gemm-f32",
  "gemm-f64",
  "num-complex",
@@ -415,12 +455,31 @@ checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
 dependencies = [
  "bytemuck",
  "dyn-stack",
+ "half",
  "libm",
  "num-complex",
  "num-traits",
  "once_cell",
  "paste",
  "pulp",
+ "raw-cpuid",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
  "raw-cpuid",
  "seq-macro",
 ]
@@ -479,15 +538,34 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
+ "num-traits",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+
+[[package]]
+name = "interpol"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb58032ba748f4010d15912a1855a8a0b1ba9eaad3395b0c171c09b3b356ae50"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "is-terminal"
@@ -538,7 +616,7 @@ checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -693,6 +771,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +848,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "private-gemm-x86"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af8c3e5087969c323f667ccb4b789fa0954f5aa650550e38e81cf9108be21b5"
+dependencies = [
+ "defer",
+ "interpol",
+ "num_cpus",
+ "raw-cpuid",
 ]
 
 [[package]]
@@ -965,7 +1065,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -982,6 +1082,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
@@ -989,6 +1100,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1054,7 +1199,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -1076,7 +1221,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1208,5 +1353,5 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rand = "0.9.3"
 rand_distr = "0.5.0"
 rayon = "1.10.0"
 
-[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 faer = { version = "0.22.6", default-features = false, features = ["linalg", "std"] }
 
 [profile.dev.package.faer]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ rand = "0.9.3"
 rand_distr = "0.5.0"
 rayon = "1.10.0"
 
+[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
+faer = { version = "0.22.6", default-features = false, features = ["linalg", "std"] }
+
 [profile.dev.package.faer]
 opt-level = 3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,7 @@ criterion = "0.5.1"
 [[bench]]
 name = "bench"
 harness = false
+
+[[bench]]
+name = "kmeans"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,12 +1,18 @@
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use gathers::distance::{
-    Distance, l2_norm, l2_norm_native, native_argmin, native_dot_product, native_squared_euclidean,
-    neg_dot_product, squared_euclidean,
+    Distance, l2_norm_native, native_argmin, native_dot_product, native_squared_euclidean,
+};
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+use gathers::distance::{
+    l2_norm as dispatched_l2_norm, neg_dot_product as dispatched_neg_dot_product,
+    squared_euclidean as dispatched_squared_euclidean,
 };
 use gathers::kmeans::{KMeans, base_assign_parallel};
 use gathers::rabitq::{binary_dot_product_native, min_max_residual, min_max_residual_native};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use gathers::simd::{self, argmin, dot_product, l2_norm as simd_l2_norm, l2_squared_distance};
+use gathers::simd::{self, argmin, dot_product, l2_norm, l2_squared_distance};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use pulp::x86::V3;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
@@ -22,10 +28,17 @@ pub fn l2_norm_benchmark(c: &mut Criterion) {
         });
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         group.bench_with_input(BenchmarkId::new("simd", dim), &x, |b, input| {
-            b.iter(|| unsafe { simd_l2_norm(input) })
+            b.iter(|| unsafe { l2_norm(input) })
         });
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if let Some(simd) = V3::try_new() {
+            group.bench_with_input(BenchmarkId::new("pulp", dim), &x, |b, input| {
+                b.iter(|| simd::pulp::l2_norm(simd, input))
+            });
+        }
+        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
         group.bench_with_input(BenchmarkId::new("pulp", dim), &x, |b, input| {
-            b.iter(|| l2_norm(input))
+            b.iter(|| dispatched_l2_norm(input))
         });
     }
     group.finish();
@@ -88,6 +101,13 @@ pub fn argmin_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("simd", dim), &x, |b, input| {
             b.iter(|| unsafe { argmin(input) })
         });
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if let Some(simd) = V3::try_new() {
+            group.bench_with_input(BenchmarkId::new("pulp", dim), &x, |b, input| {
+                b.iter(|| simd::pulp::argmin(simd, input))
+            });
+        }
+        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
         group.bench_with_input(BenchmarkId::new("pulp", dim), &x, |b, input| {
             b.iter(|| gathers::distance::argmin(input))
         });
@@ -111,8 +131,15 @@ pub fn l2_distance_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("simd", dim), &(&lhs, &rhs), |b, input| {
             b.iter(|| unsafe { l2_squared_distance(input.0, input.1) })
         });
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if let Some(simd) = V3::try_new() {
+            group.bench_with_input(BenchmarkId::new("pulp", dim), &(&lhs, &rhs), |b, input| {
+                b.iter(|| simd::pulp::l2_squared_distance(simd, input.0, input.1))
+            });
+        }
+        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
         group.bench_with_input(BenchmarkId::new("pulp", dim), &(&lhs, &rhs), |b, input| {
-            b.iter(|| squared_euclidean(input.0, input.1))
+            b.iter(|| dispatched_squared_euclidean(input.0, input.1))
         });
     }
     group.finish();
@@ -135,8 +162,15 @@ pub fn ip_distance_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("simd", dim), &(&lhs, &rhs), |b, input| {
             b.iter(|| unsafe { dot_product(input.0, input.1) })
         });
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if let Some(simd) = V3::try_new() {
+            group.bench_with_input(BenchmarkId::new("pulp", dim), &(&lhs, &rhs), |b, input| {
+                b.iter(|| simd::pulp::dot_product(simd, input.0, input.1))
+            });
+        }
+        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
         group.bench_with_input(BenchmarkId::new("pulp", dim), &(&lhs, &rhs), |b, input| {
-            b.iter(|| neg_dot_product(input.0, input.1))
+            b.iter(|| dispatched_neg_dot_product(input.0, input.1))
         });
     }
     group.finish();

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,11 +1,14 @@
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use gathers::distance::{
-    l2_norm_native, native_argmin, native_dot_product, native_squared_euclidean,
+    Distance, l2_norm, l2_norm_native, native_argmin, native_dot_product, native_squared_euclidean,
+    neg_dot_product, squared_euclidean,
 };
+use gathers::kmeans::{KMeans, base_assign_parallel};
 use gathers::rabitq::{binary_dot_product_native, min_max_residual, min_max_residual_native};
-use gathers::simd::{self, argmin, dot_product, l2_norm, l2_squared_distance};
-use pulp::x86::V3;
-use rand::Rng;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use gathers::simd::{self, argmin, dot_product, l2_norm as simd_l2_norm, l2_squared_distance};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 
 pub fn l2_norm_benchmark(c: &mut Criterion) {
     let mut rng = rand::rng();
@@ -17,14 +20,13 @@ pub fn l2_norm_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("native", dim), &x, |b, input| {
             b.iter(|| l2_norm_native(input))
         });
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         group.bench_with_input(BenchmarkId::new("simd", dim), &x, |b, input| {
-            b.iter(|| unsafe { l2_norm(input) })
+            b.iter(|| unsafe { simd_l2_norm(input) })
         });
-        if let Some(simd) = V3::try_new() {
-            group.bench_with_input(BenchmarkId::new("pulp", dim), &x, |b, input| {
-                b.iter(|| simd::pulp::l2_norm(simd, input))
-            });
-        }
+        group.bench_with_input(BenchmarkId::new("pulp", dim), &x, |b, input| {
+            b.iter(|| l2_norm(input))
+        });
     }
     group.finish();
 }
@@ -48,6 +50,7 @@ pub fn min_max_benchmark(c: &mut Criterion) {
                 });
             },
         );
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         group.bench_with_input(
             BenchmarkId::new("simd", dim),
             &(&residual, &x, &y),
@@ -81,14 +84,13 @@ pub fn argmin_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("native", dim), &x, |b, input| {
             b.iter(|| native_argmin(input))
         });
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         group.bench_with_input(BenchmarkId::new("simd", dim), &x, |b, input| {
             b.iter(|| unsafe { argmin(input) })
         });
-        if let Some(simd) = V3::try_new() {
-            group.bench_with_input(BenchmarkId::new("pulp", dim), &x, |b, input| {
-                b.iter(|| simd::pulp::argmin(simd, input))
-            });
-        }
+        group.bench_with_input(BenchmarkId::new("pulp", dim), &x, |b, input| {
+            b.iter(|| gathers::distance::argmin(input))
+        });
     }
 }
 
@@ -105,14 +107,13 @@ pub fn l2_distance_benchmark(c: &mut Criterion) {
             &(&lhs, &rhs),
             |b, input| b.iter(|| native_squared_euclidean(input.0, input.1)),
         );
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         group.bench_with_input(BenchmarkId::new("simd", dim), &(&lhs, &rhs), |b, input| {
             b.iter(|| unsafe { l2_squared_distance(input.0, input.1) })
         });
-        if let Some(simd) = V3::try_new() {
-            group.bench_with_input(BenchmarkId::new("pulp", dim), &(&lhs, &rhs), |b, input| {
-                b.iter(|| simd::pulp::l2_squared_distance(simd, input.0, input.1))
-            });
-        }
+        group.bench_with_input(BenchmarkId::new("pulp", dim), &(&lhs, &rhs), |b, input| {
+            b.iter(|| squared_euclidean(input.0, input.1))
+        });
     }
     group.finish();
 }
@@ -130,14 +131,13 @@ pub fn ip_distance_benchmark(c: &mut Criterion) {
             &(&lhs, &rhs),
             |b, input| b.iter(|| native_dot_product(input.0, input.1)),
         );
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         group.bench_with_input(BenchmarkId::new("simd", dim), &(&lhs, &rhs), |b, input| {
             b.iter(|| unsafe { dot_product(input.0, input.1) })
         });
-        if let Some(simd) = V3::try_new() {
-            group.bench_with_input(BenchmarkId::new("pulp", dim), &(&lhs, &rhs), |b, input| {
-                b.iter(|| simd::pulp::dot_product(simd, input.0, input.1))
-            });
-        }
+        group.bench_with_input(BenchmarkId::new("pulp", dim), &(&lhs, &rhs), |b, input| {
+            b.iter(|| neg_dot_product(input.0, input.1))
+        });
     }
     group.finish();
 }
@@ -157,6 +157,7 @@ pub fn binary_ip_benchmark(c: &mut Criterion) {
                 b.iter(|| binary_dot_product_native(input.0, input.1));
             },
         );
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         group.bench_with_input(
             BenchmarkId::new("simd", dim * 64),
             &(&lhs, &rhs),
@@ -164,6 +165,7 @@ pub fn binary_ip_benchmark(c: &mut Criterion) {
                 b.iter(|| unsafe { simd::binary_dot_product_simd(input.0, input.1) });
             },
         );
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         group.bench_with_input(
             BenchmarkId::new("pulp", dim * 64),
             &(&lhs, &rhs),
@@ -174,13 +176,72 @@ pub fn binary_ip_benchmark(c: &mut Criterion) {
     }
 }
 
+pub fn assignment_benchmark(c: &mut Criterion) {
+    const NUM_VECTORS: usize = 4096;
+    const NUM_CENTROIDS: usize = 256;
+    const DIM: usize = 128;
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let vecs: Vec<f32> = (0..NUM_VECTORS * DIM).map(|_| rng.random()).collect();
+    let centroids: Vec<f32> = (0..NUM_CENTROIDS * DIM).map(|_| rng.random()).collect();
+    let mut labels = vec![0; NUM_VECTORS];
+
+    let mut group = c.benchmark_group("assignment");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements((NUM_VECTORS * NUM_CENTROIDS) as u64));
+    group.bench_function("parallel_l2_4096x256x128", |b| {
+        b.iter(|| {
+            base_assign_parallel(
+                black_box(&vecs),
+                black_box(&centroids),
+                DIM,
+                Distance::SquaredEuclidean,
+                black_box(&mut labels),
+            )
+        })
+    });
+    group.finish();
+}
+
+pub fn kmeans_benchmark(c: &mut Criterion) {
+    const NUM_VECTORS: usize = 10_240;
+    const NUM_CENTROIDS: usize = 256;
+    const DIM: usize = 128;
+    const ITERATIONS: usize = 5;
+
+    let mut rng = StdRng::seed_from_u64(43);
+    let source: Vec<f32> = (0..NUM_VECTORS * DIM).map(|_| rng.random()).collect();
+    let vecs = gathers::utils::as_continuous_vec(&[source]);
+    let kmeans = KMeans::new(
+        NUM_CENTROIDS as u32,
+        ITERATIONS as u32,
+        f32::MIN_POSITIVE,
+        Distance::SquaredEuclidean,
+        false,
+    );
+
+    let mut group = c.benchmark_group("kmeans");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements(
+        (NUM_VECTORS * NUM_CENTROIDS * ITERATIONS) as u64,
+    ));
+    group.bench_function("fit_10240x256x128_5iter", |b| {
+        b.iter(|| kmeans.fit(black_box(vecs.clone()), DIM))
+    });
+    group.finish();
+}
+
 criterion_group!(l2_benches, l2_distance_benchmark);
 criterion_group!(ip_benches, ip_distance_benchmark);
 criterion_group!(norm_benches, l2_norm_benchmark);
 criterion_group!(argmin_benches, argmin_benchmark);
 criterion_group!(min_max_benches, min_max_benchmark);
 criterion_group!(binary_ip_benches, binary_ip_benchmark);
+criterion_group!(assignment_benches, assignment_benchmark);
+criterion_group!(kmeans_benches, kmeans_benchmark);
 criterion_main!(
+    kmeans_benches,
+    assignment_benches,
     l2_benches,
     ip_benches,
     norm_benches,

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,20 +1,18 @@
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use gathers::distance::{
-    Distance, l2_norm_native, native_argmin, native_dot_product, native_squared_euclidean,
-};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 use gathers::distance::{
     l2_norm as dispatched_l2_norm, neg_dot_product as dispatched_neg_dot_product,
     squared_euclidean as dispatched_squared_euclidean,
 };
-use gathers::kmeans::{KMeans, base_assign_parallel};
+use gathers::distance::{
+    l2_norm_native, native_argmin, native_dot_product, native_squared_euclidean,
+};
 use gathers::rabitq::{binary_dot_product_native, min_max_residual, min_max_residual_native};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use gathers::simd::{self, argmin, dot_product, l2_norm, l2_squared_distance};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use pulp::x86::V3;
-use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 
 pub fn l2_norm_benchmark(c: &mut Criterion) {
     let mut rng = rand::rng();
@@ -210,72 +208,13 @@ pub fn binary_ip_benchmark(c: &mut Criterion) {
     }
 }
 
-pub fn assignment_benchmark(c: &mut Criterion) {
-    const NUM_VECTORS: usize = 4096;
-    const NUM_CENTROIDS: usize = 256;
-    const DIM: usize = 128;
-
-    let mut rng = StdRng::seed_from_u64(42);
-    let vecs: Vec<f32> = (0..NUM_VECTORS * DIM).map(|_| rng.random()).collect();
-    let centroids: Vec<f32> = (0..NUM_CENTROIDS * DIM).map(|_| rng.random()).collect();
-    let mut labels = vec![0; NUM_VECTORS];
-
-    let mut group = c.benchmark_group("assignment");
-    group.sample_size(20);
-    group.throughput(Throughput::Elements((NUM_VECTORS * NUM_CENTROIDS) as u64));
-    group.bench_function("parallel_l2_4096x256x128", |b| {
-        b.iter(|| {
-            base_assign_parallel(
-                black_box(&vecs),
-                black_box(&centroids),
-                DIM,
-                Distance::SquaredEuclidean,
-                black_box(&mut labels),
-            )
-        })
-    });
-    group.finish();
-}
-
-pub fn kmeans_benchmark(c: &mut Criterion) {
-    const NUM_VECTORS: usize = 10_240;
-    const NUM_CENTROIDS: usize = 256;
-    const DIM: usize = 128;
-    const ITERATIONS: usize = 5;
-
-    let mut rng = StdRng::seed_from_u64(43);
-    let source: Vec<f32> = (0..NUM_VECTORS * DIM).map(|_| rng.random()).collect();
-    let vecs = gathers::utils::as_continuous_vec(&[source]);
-    let kmeans = KMeans::new(
-        NUM_CENTROIDS as u32,
-        ITERATIONS as u32,
-        f32::MIN_POSITIVE,
-        Distance::SquaredEuclidean,
-        false,
-    );
-
-    let mut group = c.benchmark_group("kmeans");
-    group.sample_size(20);
-    group.throughput(Throughput::Elements(
-        (NUM_VECTORS * NUM_CENTROIDS * ITERATIONS) as u64,
-    ));
-    group.bench_function("fit_10240x256x128_5iter", |b| {
-        b.iter(|| kmeans.fit(black_box(vecs.clone()), DIM))
-    });
-    group.finish();
-}
-
 criterion_group!(l2_benches, l2_distance_benchmark);
 criterion_group!(ip_benches, ip_distance_benchmark);
 criterion_group!(norm_benches, l2_norm_benchmark);
 criterion_group!(argmin_benches, argmin_benchmark);
 criterion_group!(min_max_benches, min_max_benchmark);
 criterion_group!(binary_ip_benches, binary_ip_benchmark);
-criterion_group!(assignment_benches, assignment_benchmark);
-criterion_group!(kmeans_benches, kmeans_benchmark);
 criterion_main!(
-    kmeans_benches,
-    assignment_benches,
     l2_benches,
     ip_benches,
     norm_benches,

--- a/benches/kmeans.rs
+++ b/benches/kmeans.rs
@@ -1,0 +1,64 @@
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use gathers::distance::Distance;
+use gathers::kmeans::{KMeans, base_assign_parallel};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+pub fn assignment_benchmark(c: &mut Criterion) {
+    const NUM_VECTORS: usize = 4096;
+    const NUM_CENTROIDS: usize = 256;
+    const DIM: usize = 128;
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let vecs: Vec<f32> = (0..NUM_VECTORS * DIM).map(|_| rng.random()).collect();
+    let centroids: Vec<f32> = (0..NUM_CENTROIDS * DIM).map(|_| rng.random()).collect();
+    let mut labels = vec![0; NUM_VECTORS];
+
+    let mut group = c.benchmark_group("assignment");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements((NUM_VECTORS * NUM_CENTROIDS) as u64));
+    group.bench_function("parallel_l2_4096x256x128", |b| {
+        b.iter(|| {
+            base_assign_parallel(
+                black_box(&vecs),
+                black_box(&centroids),
+                DIM,
+                Distance::SquaredEuclidean,
+                black_box(&mut labels),
+            )
+        })
+    });
+    group.finish();
+}
+
+pub fn kmeans_benchmark(c: &mut Criterion) {
+    const NUM_VECTORS: usize = 10_240;
+    const NUM_CENTROIDS: usize = 256;
+    const DIM: usize = 128;
+    const ITERATIONS: usize = 5;
+
+    let mut rng = StdRng::seed_from_u64(43);
+    let source: Vec<f32> = (0..NUM_VECTORS * DIM).map(|_| rng.random()).collect();
+    let vecs = gathers::utils::as_continuous_vec(&[source]);
+    let kmeans = KMeans::new(
+        NUM_CENTROIDS as u32,
+        ITERATIONS as u32,
+        f32::MIN_POSITIVE,
+        Distance::SquaredEuclidean,
+        false,
+    );
+
+    let mut group = c.benchmark_group("kmeans");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements(
+        (NUM_VECTORS * NUM_CENTROIDS * ITERATIONS) as u64,
+    ));
+    group.bench_function("fit_10240x256x128_5iter", |b| {
+        b.iter(|| kmeans.fit(black_box(vecs.clone()), DIM))
+    });
+    group.finish();
+}
+
+criterion_group!(assignment_benches, assignment_benchmark);
+criterion_group!(kmeans_benches, kmeans_benchmark);
+criterion_main!(kmeans_benches, assignment_benches);

--- a/macos-performance-summary.md
+++ b/macos-performance-summary.md
@@ -1,63 +1,78 @@
-# Apple Silicon K-Means Performance Optimization Summary
+# macOS K-Means Performance Optimization Summary
 
 Date: July 15, 2026
 
 ## Conclusion
 
-This optimization reduced the mean execution time of the fixed Apple Silicon
-K-Means benchmark from `27.821 ms` to `12.904 ms`. The optimized implementation
-is `2.16x` as fast, representing a `53.6%` reduction in execution time.
+The matrix-assignment optimization benefits both macOS architectures tested:
 
-The optimized code is isolated at compile time with
-`cfg(all(target_os = "macos", target_arch = "aarch64"))`. x86 and x86_64 builds
-neither compile nor call the new matrix assignment path and continue to use the
-original `base_assign_parallel` implementation. Therefore, this production-code
-optimization does not change the x86 execution path.
+| Target | Baseline mean | Optimized mean | Speedup | Time reduction |
+| --- | ---: | ---: | ---: | ---: |
+| Apple Silicon arm64 | `27.821 ms` | `12.904 ms` | `2.16x` | `53.6%` |
+| Intel macOS x86_64 under Rosetta | `1.0963 s` | `60.882 ms` | `18.0x` | `94.4%` |
+
+The x86_64 result was measured before and after changing only the macOS compile
+gate for the matrix path. It shows that the algorithmic changes and Faer's x86
+GEMM backend are also effective for Intel macOS. The optimized production path
+therefore compiles on both `aarch64-apple-darwin` and
+`x86_64-apple-darwin`. Other operating systems retain the original assignment
+implementation.
 
 ## Measurement Method and Results
 
-Test environment:
+Common setup:
 
-- System: macOS Darwin 25.5.0 on Apple Silicon arm64
+- Host: macOS Darwin 25.5.0 on Apple Silicon
 - Rust: `rustc 1.93.1 (01f6ddf75 2026-02-11)`
 - Benchmark framework: Criterion using the release benchmark profile
 - Workload: 10,240 vectors with 128 dimensions, 256 centroids, and 5 iterations
 - Random seed: 43, ensuring identical input before and after the optimization
-- Baseline revision: `3507c09`
+- Apple Silicon baseline revision: `3507c09`
+- x86_64 baseline: `c8fa604`, where the matrix path was compile-time disabled
+  for x86_64 and the production assignment path still matched `3507c09`
 
-Results:
+Detailed Criterion results:
 
-| Version | Criterion time interval | Mean time | Relative speed |
+| Target and version | Criterion time interval | Mean time | Relative speed |
 | --- | ---: | ---: | ---: |
-| Baseline | `26.959–28.642 ms` | `27.821 ms` | `1.00x` |
-| Optimized | `11.883–14.323 ms` | `12.904 ms` | `2.16x` |
+| arm64 baseline | `26.959–28.642 ms` | `27.821 ms` | `1.00x` |
+| arm64 optimized | `11.883–14.323 ms` | `12.904 ms` | `2.16x` |
+| x86_64 baseline under Rosetta | `1.0854–1.1062 s` | `1.0963 s` | `1.00x` |
+| x86_64 optimized under Rosetta | `59.196–63.179 ms` | `60.882 ms` | `18.0x` |
 
-The relative speed is calculated as `27.821 / 12.904 = 2.16`. Criterion intervals
-vary with machine temperature and background load, so the reported speedup uses
-the central estimates from the two measurements.
+The relative speeds use the central estimates. Criterion intervals vary with
+machine temperature and background load. Rosetta results should not be treated
+as absolute native Intel timings, but the before/after comparison uses the same
+host, x86_64 target, toolchain, input, and benchmark parameters, making it strong
+evidence for enabling the path on Intel macOS.
 
-Reproduction command:
+Reproduction commands:
 
 ```shell
+# Native Apple Silicon
 cargo bench --locked --bench kmeans kmeans -- \
+  --warm-up-time 3 --measurement-time 10 --noplot
+
+# x86_64 under Rosetta
+rustup target add x86_64-apple-darwin --toolchain stable-aarch64-apple-darwin
+cargo bench --locked --target x86_64-apple-darwin --bench kmeans kmeans -- \
   --warm-up-time 3 --measurement-time 10 --noplot
 ```
 
 ## Implementation Overview
 
 The main hotspot was assigning every vector to its nearest centroid during each
-iteration. On Apple Silicon, the optimized path uses the identity
+iteration. On macOS, the optimized path uses the identity
 
 `||x-c||^2 = ||x||^2 + ||c||^2 - 2 x·c`
 
 to replace a large number of pairwise distance calculations with blocked matrix
-multiplication. The implementation also includes the following safeguards and
+multiplication. The implementation includes the following safeguards and
 optimizations:
 
 - Vector norms, centroid norms, and the dot-product workspace are reused to avoid
   reallocating large buffers on every iteration.
-- Matrix multiplication is processed in parallel blocks of 256 rows to make
-  better use of Apple Silicon.
+- Matrix multiplication is processed in parallel blocks of 256 rows.
 - The workspace is limited to 128 MiB. Oversized or small workloads automatically
   fall back to the original implementation.
 - Only squared Euclidean distance uses the optimized path. Other distance types
@@ -65,37 +80,23 @@ optimizations:
 - Candidates affected by possible floating-point cancellation are verified with
   the original direct distance formula.
 - Tests with random inputs and large common offsets verify that assignments match
-  direct distance calculation.
+  direct distance calculation on both macOS architectures.
 
-## x86 Performance Isolation
+## Platform Scope and Benchmark Isolation
 
-The optimization uses compile-time isolation at both the source and dependency
-levels rather than a runtime branch:
+The optimization uses compile-time isolation rather than adding a runtime
+platform branch:
 
-1. The matrix workspace, Faer matrix multiplication, thresholds, and new tests
-   compile only for `macOS + aarch64`.
-2. On x86 and x86_64, `base_assign` is identical to the baseline implementation.
-   The original body of `base_assign_parallel` is unchanged, and the new entry
-   path is removed during conditional compilation.
-3. On targets other than `macOS + aarch64`, the K-Means training loop continues
-   to call the original `base_assign_parallel` directly.
-4. The `faer/std` feature is enabled only for `aarch64-apple-darwin`. Target-aware
-   dependency resolution produced the following feature sets:
-
-```text
-x86_64-apple-darwin: faer features = [linalg]
-aarch64-apple-darwin: faer features = [linalg, std]
-```
-
-The architecture conditions in `benches/bench.rs`, `src/simd.rs`, and
-`src/rabitq.rs` only allow benchmarks and tests to compile on ARM. They do not
-modify any x86 production function.
-
-The current machine does not have the Rust `x86_64-apple-darwin` standard library
-installed, so a dynamic x86 benchmark under Rosetta was not executed. The
-no-regression conclusion for x86 is instead based on stronger compile-time path
-isolation and target-aware dependency resolution: none of the new optimized code
-is included in an x86 binary.
+1. The matrix workspace, Faer matrix multiplication, thresholds, and correctness
+   tests compile for `target_os = "macos"`, covering arm64 and x86_64.
+2. Linux, Windows, and other operating systems continue to call the original
+   `base_assign_parallel` implementation.
+3. The `faer/std` feature is enabled only for macOS targets; other targets retain
+   the original dependency feature set.
+4. Existing x86 microbenchmarks keep their original direct SIMD and
+   `pulp::x86::V3` calls. The new assignment and K-Means cases live in the
+   separate `kmeans` benchmark target so they do not perturb the old benchmark
+   binary.
 
 Dependency verification commands:
 
@@ -106,7 +107,7 @@ cargo tree --locked --target aarch64-apple-darwin -e features -i faer
 
 ## Correctness and Engineering Validation
 
-The final changes passed the following checks:
+Native Apple Silicon validation:
 
 ```shell
 cargo +nightly fmt --all -- --check
@@ -116,3 +117,17 @@ cargo test --all-targets --locked
 cargo check --locked --manifest-path python/Cargo.toml
 git diff --check
 ```
+
+x86_64 macOS validation:
+
+```shell
+cargo check --all-targets --locked --target x86_64-apple-darwin
+cargo clippy --all-targets --locked --target x86_64-apple-darwin -- -D warnings
+cargo test --locked --target x86_64-apple-darwin --lib --bins
+```
+
+The x86_64 library suite passed all 12 tests under Rosetta, including both
+matrix-assignment correctness tests. Running every legacy benchmark as a test
+under Rosetta is not supported because the existing binary-dot-product benchmark
+assumes AVX availability; native Intel CI remains the authoritative check for
+that pre-existing benchmark path.

--- a/macos-performance-summary.md
+++ b/macos-performance-summary.md
@@ -1,0 +1,118 @@
+# Apple Silicon K-Means Performance Optimization Summary
+
+Date: July 15, 2026
+
+## Conclusion
+
+This optimization reduced the mean execution time of the fixed Apple Silicon
+K-Means benchmark from `27.821 ms` to `12.904 ms`. The optimized implementation
+is `2.16x` as fast, representing a `53.6%` reduction in execution time.
+
+The optimized code is isolated at compile time with
+`cfg(all(target_os = "macos", target_arch = "aarch64"))`. x86 and x86_64 builds
+neither compile nor call the new matrix assignment path and continue to use the
+original `base_assign_parallel` implementation. Therefore, this production-code
+optimization does not change the x86 execution path.
+
+## Measurement Method and Results
+
+Test environment:
+
+- System: macOS Darwin 25.5.0 on Apple Silicon arm64
+- Rust: `rustc 1.93.1 (01f6ddf75 2026-02-11)`
+- Benchmark framework: Criterion using the release benchmark profile
+- Workload: 10,240 vectors with 128 dimensions, 256 centroids, and 5 iterations
+- Random seed: 43, ensuring identical input before and after the optimization
+- Baseline revision: `3507c09`
+
+Results:
+
+| Version | Criterion time interval | Mean time | Relative speed |
+| --- | ---: | ---: | ---: |
+| Baseline | `26.959–28.642 ms` | `27.821 ms` | `1.00x` |
+| Optimized | `11.883–14.323 ms` | `12.904 ms` | `2.16x` |
+
+The relative speed is calculated as `27.821 / 12.904 = 2.16`. Criterion intervals
+vary with machine temperature and background load, so the reported speedup uses
+the central estimates from the two measurements.
+
+Reproduction command:
+
+```shell
+cargo bench --locked --bench bench kmeans -- \
+  --warm-up-time 3 --measurement-time 10 --noplot
+```
+
+## Implementation Overview
+
+The main hotspot was assigning every vector to its nearest centroid during each
+iteration. On Apple Silicon, the optimized path uses the identity
+
+`||x-c||^2 = ||x||^2 + ||c||^2 - 2 x·c`
+
+to replace a large number of pairwise distance calculations with blocked matrix
+multiplication. The implementation also includes the following safeguards and
+optimizations:
+
+- Vector norms, centroid norms, and the dot-product workspace are reused to avoid
+  reallocating large buffers on every iteration.
+- Matrix multiplication is processed in parallel blocks of 256 rows to make
+  better use of Apple Silicon.
+- The workspace is limited to 128 MiB. Oversized or small workloads automatically
+  fall back to the original implementation.
+- Only squared Euclidean distance uses the optimized path. Other distance types
+  retain their original implementations.
+- Candidates affected by possible floating-point cancellation are verified with
+  the original direct distance formula.
+- Tests with random inputs and large common offsets verify that assignments match
+  direct distance calculation.
+
+## x86 Performance Isolation
+
+The optimization uses compile-time isolation at both the source and dependency
+levels rather than a runtime branch:
+
+1. The matrix workspace, Faer matrix multiplication, thresholds, and new tests
+   compile only for `macOS + aarch64`.
+2. On x86 and x86_64, `base_assign` is identical to the baseline implementation.
+   The original body of `base_assign_parallel` is unchanged, and the new entry
+   path is removed during conditional compilation.
+3. On targets other than `macOS + aarch64`, the K-Means training loop continues
+   to call the original `base_assign_parallel` directly.
+4. The `faer/std` feature is enabled only for `aarch64-apple-darwin`. Target-aware
+   dependency resolution produced the following feature sets:
+
+```text
+x86_64-apple-darwin: faer features = [linalg]
+aarch64-apple-darwin: faer features = [linalg, std]
+```
+
+The architecture conditions in `benches/bench.rs`, `src/simd.rs`, and
+`src/rabitq.rs` only allow benchmarks and tests to compile on ARM. They do not
+modify any x86 production function.
+
+The current machine does not have the Rust `x86_64-apple-darwin` standard library
+installed, so a dynamic x86 benchmark under Rosetta was not executed. The
+no-regression conclusion for x86 is instead based on stronger compile-time path
+isolation and target-aware dependency resolution: none of the new optimized code
+is included in an x86 binary.
+
+Dependency verification commands:
+
+```shell
+cargo tree --locked --target x86_64-apple-darwin -e features -i faer
+cargo tree --locked --target aarch64-apple-darwin -e features -i faer
+```
+
+## Correctness and Engineering Validation
+
+The final changes passed the following checks:
+
+```shell
+cargo +nightly fmt --all -- --check
+cargo clippy --all-targets --locked -- -D warnings
+cargo clippy --locked --manifest-path python/Cargo.toml -- -D warnings
+cargo test --all-targets --locked
+cargo check --locked --manifest-path python/Cargo.toml
+git diff --check
+```

--- a/macos-performance-summary.md
+++ b/macos-performance-summary.md
@@ -39,7 +39,7 @@ the central estimates from the two measurements.
 Reproduction command:
 
 ```shell
-cargo bench --locked --bench bench kmeans -- \
+cargo bench --locked --bench kmeans kmeans -- \
   --warm-up-time 3 --measurement-time 10 --noplot
 ```
 

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -75,6 +75,26 @@ name = "bytemuck"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -108,6 +128,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "defer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
+
+[[package]]
 name = "dyn-stack"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +153,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "env_filter"
@@ -158,7 +202,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -169,7 +213,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -189,6 +233,7 @@ dependencies = [
  "nano-gemm",
  "num-complex",
  "num-traits",
+ "private-gemm-x86",
  "pulp",
  "reborrow",
 ]
@@ -201,7 +246,7 @@ checksum = "9d0a255d1442b5825c61812a7eafda9034ec53d969c98555251085e148428e6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -258,6 +303,7 @@ dependencies = [
  "gemm-c32",
  "gemm-c64",
  "gemm-common",
+ "gemm-f16",
  "gemm-f32",
  "gemm-f64",
  "num-complex",
@@ -305,12 +351,31 @@ checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
 dependencies = [
  "bytemuck",
  "dyn-stack",
+ "half",
  "libm",
  "num-complex",
  "num-traits",
  "once_cell",
  "paste",
  "pulp",
+ "raw-cpuid",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
  "raw-cpuid",
  "seq-macro",
 ]
@@ -364,16 +429,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "interpol"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb58032ba748f4010d15912a1855a8a0b1ba9eaad3395b0c171c09b3b356ae50"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "jiff"
@@ -398,7 +492,7 @@ checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -586,6 +680,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "numpy"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +739,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "private-gemm-x86"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af8c3e5087969c323f667ccb4b789fa0954f5aa650550e38e81cf9108be21b5"
+dependencies = [
+ "defer",
+ "interpol",
+ "num_cpus",
+ "raw-cpuid",
 ]
 
 [[package]]
@@ -707,7 +823,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -720,7 +836,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -872,6 +988,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "seq-macro"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,7 +1019,18 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -909,10 +1045,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -933,12 +1103,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -1040,5 +1229,5 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -4,9 +4,9 @@ use core::panic;
 use std::time::Instant;
 
 use aligned_vec::AVec;
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(target_os = "macos")]
 use faer::linalg::matmul::matmul;
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(target_os = "macos")]
 use faer::{Accum, MatMut, MatRef, Par};
 use log::debug;
 use rand::Rng;
@@ -22,19 +22,19 @@ const MIN_POINTS_PER_CENTROID: usize = 39;
 const MAX_POINTS_PER_CENTROID: usize = 256;
 const LARGE_CLUSTER_THRESHOLD: usize = 1 << 28;
 const RAYON_BLOCK_SIZE: usize = 64;
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(target_os = "macos")]
 const MATRIX_ASSIGNMENT_THRESHOLD: usize = 1 << 18;
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(target_os = "macos")]
 const MAX_MATRIX_ASSIGNMENT_ELEMENTS: usize = (128 << 20) / size_of::<f32>();
 
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(target_os = "macos")]
 struct MatrixAssignmentWorkspace {
     vector_norms: Vec<f32>,
     centroid_norms: Vec<f32>,
     dot_products: Vec<f32>,
 }
 
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(target_os = "macos")]
 impl MatrixAssignmentWorkspace {
     fn try_new(vecs: &[f32], num_centroids: usize, dim: usize, distance: Distance) -> Option<Self> {
         let num_vectors = vecs.len() / dim;
@@ -198,7 +198,7 @@ pub fn base_assign_parallel(
     distance: Distance,
     labels: &mut [u32],
 ) {
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(target_os = "macos")]
     if let Some(mut workspace) =
         MatrixAssignmentWorkspace::try_new(vecs, centroids.len() / dim, dim, distance)
     {
@@ -445,7 +445,7 @@ impl KMeans {
         }
 
         let mut labels: Vec<u32> = vec![0; num];
-        #[cfg(all(not(feature = "perf"), target_os = "macos", target_arch = "aarch64"))]
+        #[cfg(all(not(feature = "perf"), target_os = "macos"))]
         let mut matrix_workspace =
             MatrixAssignmentWorkspace::try_new(&vecs, centroids.len() / dim, dim, self.distance);
         debug!("start training");
@@ -455,16 +455,13 @@ impl KMeans {
             {
                 #[cfg(feature = "perf")]
                 base_assign(&vecs, &centroids, dim, self.distance, &mut labels);
-                #[cfg(all(not(feature = "perf"), target_os = "macos", target_arch = "aarch64"))]
+                #[cfg(all(not(feature = "perf"), target_os = "macos"))]
                 if let Some(workspace) = &mut matrix_workspace {
                     workspace.assign(&vecs, &centroids, dim, &mut labels);
                 } else {
                     base_assign_parallel(&vecs, &centroids, dim, self.distance, &mut labels);
                 }
-                #[cfg(all(
-                    not(feature = "perf"),
-                    not(all(target_os = "macos", target_arch = "aarch64"))
-                ))]
+                #[cfg(all(not(feature = "perf"), not(target_os = "macos")))]
                 base_assign_parallel(&vecs, &centroids, dim, self.distance, &mut labels);
             } else {
                 #[cfg(feature = "perf")]
@@ -491,7 +488,7 @@ impl KMeans {
 mod test {
     use rand::Rng;
 
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(target_os = "macos")]
     use super::base_assign_parallel;
     use super::{KMeans, base_assign, rabitq_assign};
     use crate::distance::{Distance, argmin, squared_euclidean};
@@ -551,7 +548,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(target_os = "macos")]
     fn test_matrix_assignment_matches_direct_assignment() {
         let mut rng = rand::rng();
         let dim = 32;
@@ -585,7 +582,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(target_os = "macos")]
     fn test_matrix_assignment_handles_large_common_offset() {
         let dim = 32;
         let num_vectors = 4096;

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -4,6 +4,10 @@ use core::panic;
 use std::time::Instant;
 
 use aligned_vec::AVec;
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+use faer::linalg::matmul::matmul;
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+use faer::{Accum, MatMut, MatRef, Par};
 use log::debug;
 use rand::Rng;
 use rayon::prelude::*;
@@ -18,6 +22,144 @@ const MIN_POINTS_PER_CENTROID: usize = 39;
 const MAX_POINTS_PER_CENTROID: usize = 256;
 const LARGE_CLUSTER_THRESHOLD: usize = 1 << 28;
 const RAYON_BLOCK_SIZE: usize = 64;
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const MATRIX_ASSIGNMENT_THRESHOLD: usize = 1 << 18;
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const MAX_MATRIX_ASSIGNMENT_ELEMENTS: usize = (128 << 20) / size_of::<f32>();
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+struct MatrixAssignmentWorkspace {
+    vector_norms: Vec<f32>,
+    centroid_norms: Vec<f32>,
+    dot_products: Vec<f32>,
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+impl MatrixAssignmentWorkspace {
+    fn try_new(vecs: &[f32], num_centroids: usize, dim: usize, distance: Distance) -> Option<Self> {
+        let num_vectors = vecs.len() / dim;
+        let comparison_count = num_vectors.checked_mul(num_centroids)?;
+        if distance != Distance::SquaredEuclidean
+            || dim < 32
+            || num_centroids < 2
+            || !(MATRIX_ASSIGNMENT_THRESHOLD..=MAX_MATRIX_ASSIGNMENT_ELEMENTS)
+                .contains(&comparison_count)
+        {
+            return None;
+        }
+
+        let vector_norms = vecs
+            .par_chunks_exact(dim)
+            .map(|vector| vector.iter().map(|value| value * value).sum())
+            .collect();
+        Some(Self {
+            vector_norms,
+            centroid_norms: vec![0.0; num_centroids],
+            dot_products: vec![0.0; comparison_count],
+        })
+    }
+
+    fn assign(&mut self, vecs: &[f32], centroids: &[f32], dim: usize, labels: &mut [u32]) {
+        let num_vectors = vecs.len() / dim;
+        let num_centroids = centroids.len() / dim;
+        debug_assert_eq!(self.vector_norms.len(), num_vectors);
+        debug_assert_eq!(self.centroid_norms.len(), num_centroids);
+        debug_assert_eq!(self.dot_products.len(), num_vectors * num_centroids);
+
+        const MATMUL_BLOCK_SIZE: usize = 256;
+        self.dot_products
+            .par_chunks_mut(MATMUL_BLOCK_SIZE * num_centroids)
+            .zip(vecs.par_chunks(MATMUL_BLOCK_SIZE * dim))
+            .for_each(|(dot_products, vectors)| {
+                let block_rows = vectors.len() / dim;
+                let vectors = MatRef::from_row_major_slice(vectors, block_rows, dim);
+                let centroids = MatRef::from_row_major_slice(centroids, num_centroids, dim);
+                let scores =
+                    MatMut::from_row_major_slice_mut(dot_products, block_rows, num_centroids);
+                matmul(
+                    scores,
+                    Accum::Replace,
+                    vectors,
+                    centroids.transpose(),
+                    -2.0,
+                    Par::Seq,
+                );
+            });
+
+        self.centroid_norms
+            .par_iter_mut()
+            .zip(centroids.par_chunks_exact(dim))
+            .for_each(|(norm, centroid)| {
+                *norm = centroid.iter().map(|value| value * value).sum();
+            });
+        let max_centroid_norm = self.centroid_norms.iter().copied().fold(0.0_f32, f32::max);
+        let dimension_error = dim as f32 * f32::EPSILON;
+        let gamma = dimension_error / (1.0 - dimension_error);
+
+        labels
+            .par_iter_mut()
+            .zip(&self.vector_norms)
+            .zip(vecs.par_chunks_exact(dim))
+            .zip(self.dot_products.par_chunks_exact(num_centroids))
+            .for_each(|(((label, &vector_norm), vector), scores)| {
+                let mut best_distance = f32::MAX;
+                let mut second_best_distance = f32::MAX;
+                let mut best_index = 0;
+                for (index, (&score, &centroid_norm)) in
+                    scores.iter().zip(&self.centroid_norms).enumerate()
+                {
+                    let distance = score + vector_norm + centroid_norm;
+                    if distance < best_distance {
+                        second_best_distance = best_distance;
+                        best_distance = distance;
+                        best_index = index;
+                    } else if distance < second_best_distance {
+                        second_best_distance = distance;
+                    }
+                }
+
+                // The matrix identity can lose precision when large, nearly equal values
+                // cancel. Only trust it when the best two candidates are separated by
+                // more than a conservative floating-point error bound.
+                let uncertainty = 8.0 * gamma * (vector_norm.abs() + max_centroid_norm.abs());
+                if !best_distance.is_finite() {
+                    let mut exact_label = [0];
+                    base_assign(
+                        vector,
+                        centroids,
+                        dim,
+                        Distance::SquaredEuclidean,
+                        &mut exact_label,
+                    );
+                    *label = exact_label[0];
+                } else if best_distance < 0.0
+                    || second_best_distance - best_distance <= 2.0 * uncertainty
+                {
+                    let cutoff = best_distance + 2.0 * uncertainty;
+                    let mut exact_best_distance = f32::MAX;
+                    let mut exact_best_index = best_index;
+                    for (index, ((&score, &centroid_norm), centroid)) in scores
+                        .iter()
+                        .zip(&self.centroid_norms)
+                        .zip(centroids.chunks_exact(dim))
+                        .enumerate()
+                    {
+                        let approximate_distance = score + vector_norm + centroid_norm;
+                        if approximate_distance <= cutoff {
+                            let exact_distance = squared_euclidean(vector, centroid);
+                            if exact_distance < exact_best_distance {
+                                exact_best_distance = exact_distance;
+                                exact_best_index = index;
+                            }
+                        }
+                    }
+                    *label = exact_best_index as u32;
+                } else {
+                    *label = best_index as u32;
+                }
+            });
+    }
+}
 
 /// Assign vectors to centroids in single thread.
 pub fn base_assign(
@@ -56,6 +198,14 @@ pub fn base_assign_parallel(
     distance: Distance,
     labels: &mut [u32],
 ) {
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    if let Some(mut workspace) =
+        MatrixAssignmentWorkspace::try_new(vecs, centroids.len() / dim, dim, distance)
+    {
+        workspace.assign(vecs, centroids, dim, labels);
+        return;
+    }
+
     match distance {
         Distance::NegativeDotProduct => {
             let mut distances = vec![f32::MAX; centroids.len() / dim];
@@ -295,6 +445,9 @@ impl KMeans {
         }
 
         let mut labels: Vec<u32> = vec![0; num];
+        #[cfg(all(not(feature = "perf"), target_os = "macos", target_arch = "aarch64"))]
+        let mut matrix_workspace =
+            MatrixAssignmentWorkspace::try_new(&vecs, centroids.len() / dim, dim, self.distance);
         debug!("start training");
         for i in 0..self.max_iter {
             let start_time = Instant::now();
@@ -302,7 +455,16 @@ impl KMeans {
             {
                 #[cfg(feature = "perf")]
                 base_assign(&vecs, &centroids, dim, self.distance, &mut labels);
-                #[cfg(not(feature = "perf"))]
+                #[cfg(all(not(feature = "perf"), target_os = "macos", target_arch = "aarch64"))]
+                if let Some(workspace) = &mut matrix_workspace {
+                    workspace.assign(&vecs, &centroids, dim, &mut labels);
+                } else {
+                    base_assign_parallel(&vecs, &centroids, dim, self.distance, &mut labels);
+                }
+                #[cfg(all(
+                    not(feature = "perf"),
+                    not(all(target_os = "macos", target_arch = "aarch64"))
+                ))]
                 base_assign_parallel(&vecs, &centroids, dim, self.distance, &mut labels);
             } else {
                 #[cfg(feature = "perf")]
@@ -329,7 +491,7 @@ impl KMeans {
 mod test {
     use rand::Rng;
 
-    use super::{KMeans, base_assign, rabitq_assign};
+    use super::{KMeans, base_assign, base_assign_parallel, rabitq_assign};
     use crate::distance::{Distance, argmin, squared_euclidean};
     use crate::utils::as_continuous_vec;
 
@@ -383,6 +545,71 @@ mod test {
                 match_rate >= rabitq_match_rate,
                 "round: {r}, match rate: {match_rate}"
             );
+        }
+    }
+
+    #[test]
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    fn test_matrix_assignment_matches_direct_assignment() {
+        let mut rng = rand::rng();
+        let dim = 32;
+        let num_vectors = 4096;
+        let num_centroids = 64;
+        let vecs = (0..num_vectors * dim)
+            .map(|_| rng.random::<f32>())
+            .collect::<Vec<_>>();
+        let centroids = (0..num_centroids * dim)
+            .map(|_| rng.random::<f32>())
+            .collect::<Vec<_>>();
+        let mut expected = vec![0; num_vectors];
+        let mut actual = vec![0; num_vectors];
+
+        base_assign(
+            &vecs,
+            &centroids,
+            dim,
+            Distance::SquaredEuclidean,
+            &mut expected,
+        );
+        base_assign_parallel(
+            &vecs,
+            &centroids,
+            dim,
+            Distance::SquaredEuclidean,
+            &mut actual,
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    fn test_matrix_assignment_handles_large_common_offset() {
+        let dim = 32;
+        let num_vectors = 4096;
+        let num_centroids = 64;
+        let mut centroids = vec![1_000_000.0; num_centroids * dim];
+        for (index, centroid) in centroids.chunks_exact_mut(dim).enumerate() {
+            centroid[0] += index as f32 * 2.0;
+        }
+        let mut vecs = Vec::with_capacity(num_vectors * dim);
+        for index in 0..num_vectors {
+            let centroid = &centroids[(index % num_centroids) * dim..][..dim];
+            vecs.extend_from_slice(centroid);
+            *vecs.last_mut().unwrap() += 0.125;
+        }
+        let mut labels = vec![0; num_vectors];
+
+        base_assign_parallel(
+            &vecs,
+            &centroids,
+            dim,
+            Distance::SquaredEuclidean,
+            &mut labels,
+        );
+
+        for (index, &label) in labels.iter().enumerate() {
+            assert_eq!(label as usize, index % num_centroids);
         }
     }
 }

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -25,7 +25,7 @@ const RAYON_BLOCK_SIZE: usize = 64;
 #[cfg(target_os = "macos")]
 const MATRIX_ASSIGNMENT_THRESHOLD: usize = 1 << 18;
 #[cfg(target_os = "macos")]
-const MAX_MATRIX_ASSIGNMENT_ELEMENTS: usize = (128 << 20) / size_of::<f32>();
+const MAX_MATRIX_ASSIGNMENT_ELEMENTS: usize = (128 << 20) / std::mem::size_of::<f32>();
 
 #[cfg(target_os = "macos")]
 struct MatrixAssignmentWorkspace {
@@ -39,11 +39,14 @@ impl MatrixAssignmentWorkspace {
     fn try_new(vecs: &[f32], num_centroids: usize, dim: usize, distance: Distance) -> Option<Self> {
         let num_vectors = vecs.len() / dim;
         let comparison_count = num_vectors.checked_mul(num_centroids)?;
+        let workspace_elements = comparison_count
+            .checked_add(num_vectors)?
+            .checked_add(num_centroids)?;
         if distance != Distance::SquaredEuclidean
             || dim < 32
             || num_centroids < 2
-            || !(MATRIX_ASSIGNMENT_THRESHOLD..=MAX_MATRIX_ASSIGNMENT_ELEMENTS)
-                .contains(&comparison_count)
+            || comparison_count < MATRIX_ASSIGNMENT_THRESHOLD
+            || workspace_elements > MAX_MATRIX_ASSIGNMENT_ELEMENTS
         {
             return None;
         }
@@ -65,6 +68,7 @@ impl MatrixAssignmentWorkspace {
         debug_assert_eq!(self.vector_norms.len(), num_vectors);
         debug_assert_eq!(self.centroid_norms.len(), num_centroids);
         debug_assert_eq!(self.dot_products.len(), num_vectors * num_centroids);
+        debug_assert_eq!(labels.len(), num_vectors);
 
         const MATMUL_BLOCK_SIZE: usize = 256;
         self.dot_products

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -491,7 +491,9 @@ impl KMeans {
 mod test {
     use rand::Rng;
 
-    use super::{KMeans, base_assign, base_assign_parallel, rabitq_assign};
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    use super::base_assign_parallel;
+    use super::{KMeans, base_assign, rabitq_assign};
     use crate::distance::{Distance, argmin, squared_euclidean};
     use crate::utils::as_continuous_vec;
 

--- a/src/rabitq.rs
+++ b/src/rabitq.rs
@@ -455,10 +455,13 @@ impl RaBitQ {
 mod test {
     use rand::Rng;
 
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     use super::{
-        SCALAR, THETA_LOG_DIM, binary_dot_product_native, min_max_residual,
-        min_max_residual_native, scalar_quantize_native, vector_binarize_query_native,
+        SCALAR, THETA_LOG_DIM, binary_dot_product_native, scalar_quantize_native,
+        vector_binarize_query_native,
     };
+    use super::{min_max_residual, min_max_residual_native};
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     use crate::simd;
 
     #[test]

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -23,13 +23,11 @@ where
         res.push(iteration.next().expect("iteration less than n_sample"));
     }
 
-    let mut i = n_sample;
-    for vec in iteration.by_ref() {
+    for (i, vec) in (n_sample..).zip(iteration.by_ref()) {
         let j = rng.random_range(0..=i);
         if j < n_sample {
             res[j] = vec;
         }
-        i += 1;
     }
 
     res

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -1,7 +1,9 @@
 //! Accelerate with SIMD.
 
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 use core::iter;
 
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 use crate::rabitq::THETA_LOG_DIM;
 
 pub mod pulp;


### PR DESCRIPTION
## Summary

- use blocked matrix multiplication for large squared-Euclidean assignments on macOS arm64 and x86_64
- reuse assignment workspaces and fall back for small, oversized, non-Euclidean, or numerically uncertain workloads
- add correctness tests and a separate Criterion benchmark target with a reproducible performance report
- keep Linux, Windows, and existing x86 microbenchmark production/call paths unchanged

## Performance

Fixed workload: 10,240 vectors, 128 dimensions, 256 centroids, 5 iterations.

- Apple Silicon arm64: 27.821 ms to 12.904 ms (2.16x faster, 53.6% lower mean time)
- macOS x86_64 under Rosetta: 1.0963 s to 60.882 ms (18.0x faster, 94.4% lower mean time)

The Rosetta comparison uses the same host, x86_64 target, toolchain, input, and Criterion parameters before and after changing only the macOS compile gate. See `macos-performance-summary.md` for full methodology and limitations.

## Benchmark compatibility

Existing x86 microbenchmarks retain their original direct SIMD and `pulp::x86::V3` calls. New K-Means benchmarks live in a separate `kmeans` bench target. CodSpeed currently warns that no successful baseline exists for current `main` (`3507c09`), falls back to older `84a2672`, and compares across the breaking `codspeed-rust` 5.0.1 runtime change; changes in untouched microbenchmarks are therefore not a like-for-like production regression.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo clippy --locked --manifest-path python/Cargo.toml -- -D warnings`
- `cargo test --all-targets --locked`
- `cargo check --locked --manifest-path python/Cargo.toml`
- `cargo check --all-targets --locked --target x86_64-apple-darwin`
- `cargo clippy --all-targets --locked --target x86_64-apple-darwin -- -D warnings`
- `cargo test --locked --target x86_64-apple-darwin --lib --bins`
- `git diff --check`