### PR TITLE
feat: add the arm pulp simd support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,7 @@ criterion = "0.5.1"
 [[bench]]
 name = "bench"
 harness = false
+
+[[bench]]
+name = "kmeans"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,8 +2,12 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use gathers::distance::{
     l2_norm_native, native_argmin, native_dot_product, native_squared_euclidean,
 };
-use gathers::rabitq::{binary_dot_product_native, min_max_residual, min_max_residual_native};
+use gathers::rabitq::{binary_dot_product_native, min_max_residual_native};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use gathers::simd::{self, argmin, dot_product, l2_norm, l2_squared_distance};
+#[cfg(target_arch = "aarch64")]
+use pulp::aarch64::Neon;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use pulp::x86::V3;
 use rand::Rng;
 
@@ -17,12 +21,20 @@ pub fn l2_norm_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("native", dim), &x, |b, input| {
             b.iter(|| l2_norm_native(input))
         });
-        group.bench_with_input(BenchmarkId::new("simd", dim), &x, |b, input| {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        group.bench_with_input(BenchmarkId::new("simd_avx2", dim), &x, |b, input| {
             b.iter(|| unsafe { l2_norm(input) })
         });
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         if let Some(simd) = V3::try_new() {
-            group.bench_with_input(BenchmarkId::new("pulp", dim), &x, |b, input| {
+            group.bench_with_input(BenchmarkId::new("pulp_avx2", dim), &x, |b, input| {
                 b.iter(|| simd::pulp::l2_norm(simd, input))
+            });
+        }
+        #[cfg(target_arch = "aarch64")]
+        if let Some(simd) = Neon::try_new() {
+            group.bench_with_input(BenchmarkId::new("pulp_neon", dim), &x, |b, input| {
+                b.iter(|| gathers::simd::pulp::l2_norm(simd, input))
             });
         }
     }
@@ -48,8 +60,9 @@ pub fn min_max_benchmark(c: &mut Criterion) {
                 });
             },
         );
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         group.bench_with_input(
-            BenchmarkId::new("simd", dim),
+            BenchmarkId::new("simd_avx2", dim),
             &(&residual, &x, &y),
             |b, input| {
                 b.iter(|| {
@@ -58,16 +71,32 @@ pub fn min_max_benchmark(c: &mut Criterion) {
                 });
             },
         );
-        group.bench_with_input(
-            BenchmarkId::new("pulp", dim),
-            &(&residual, &x, &y),
-            |b, input| {
-                b.iter(|| {
-                    let mut res = input.0.clone();
-                    min_max_residual(&mut res, input.1, input.2)
-                });
-            },
-        );
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if let Some(simd) = V3::try_new() {
+            group.bench_with_input(
+                BenchmarkId::new("pulp_avx2", dim),
+                &(&residual, &x, &y),
+                |b, input| {
+                    b.iter(|| {
+                        let mut res = input.0.clone();
+                        gathers::simd::pulp::min_max_residual(simd, &mut res, input.1, input.2)
+                    });
+                },
+            );
+        }
+        #[cfg(target_arch = "aarch64")]
+        if let Some(simd) = Neon::try_new() {
+            group.bench_with_input(
+                BenchmarkId::new("pulp_neon", dim),
+                &(&residual, &x, &y),
+                |b, input| {
+                    b.iter(|| {
+                        let mut res = input.0.clone();
+                        gathers::simd::pulp::min_max_residual(simd, &mut res, input.1, input.2)
+                    });
+                },
+            );
+        }
     }
 }
 
@@ -81,12 +110,20 @@ pub fn argmin_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("native", dim), &x, |b, input| {
             b.iter(|| native_argmin(input))
         });
-        group.bench_with_input(BenchmarkId::new("simd", dim), &x, |b, input| {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        group.bench_with_input(BenchmarkId::new("simd_avx2", dim), &x, |b, input| {
             b.iter(|| unsafe { argmin(input) })
         });
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         if let Some(simd) = V3::try_new() {
-            group.bench_with_input(BenchmarkId::new("pulp", dim), &x, |b, input| {
+            group.bench_with_input(BenchmarkId::new("pulp_avx2", dim), &x, |b, input| {
                 b.iter(|| simd::pulp::argmin(simd, input))
+            });
+        }
+        #[cfg(target_arch = "aarch64")]
+        if let Some(simd) = Neon::try_new() {
+            group.bench_with_input(BenchmarkId::new("pulp_neon", dim), &x, |b, input| {
+                b.iter(|| gathers::simd::pulp::argmin(simd, input))
             });
         }
     }
@@ -105,13 +142,29 @@ pub fn l2_distance_benchmark(c: &mut Criterion) {
             &(&lhs, &rhs),
             |b, input| b.iter(|| native_squared_euclidean(input.0, input.1)),
         );
-        group.bench_with_input(BenchmarkId::new("simd", dim), &(&lhs, &rhs), |b, input| {
-            b.iter(|| unsafe { l2_squared_distance(input.0, input.1) })
-        });
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        group.bench_with_input(
+            BenchmarkId::new("simd_avx2", dim),
+            &(&lhs, &rhs),
+            |b, input| b.iter(|| unsafe { l2_squared_distance(input.0, input.1) }),
+        );
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         if let Some(simd) = V3::try_new() {
-            group.bench_with_input(BenchmarkId::new("pulp", dim), &(&lhs, &rhs), |b, input| {
-                b.iter(|| simd::pulp::l2_squared_distance(simd, input.0, input.1))
-            });
+            group.bench_with_input(
+                BenchmarkId::new("pulp_avx2", dim),
+                &(&lhs, &rhs),
+                |b, input| b.iter(|| simd::pulp::l2_squared_distance(simd, input.0, input.1)),
+            );
+        }
+        #[cfg(target_arch = "aarch64")]
+        if let Some(simd) = Neon::try_new() {
+            group.bench_with_input(
+                BenchmarkId::new("pulp_neon", dim),
+                &(&lhs, &rhs),
+                |b, input| {
+                    b.iter(|| gathers::simd::pulp::l2_squared_distance(simd, input.0, input.1))
+                },
+            );
         }
     }
     group.finish();
@@ -130,13 +183,27 @@ pub fn ip_distance_benchmark(c: &mut Criterion) {
             &(&lhs, &rhs),
             |b, input| b.iter(|| native_dot_product(input.0, input.1)),
         );
-        group.bench_with_input(BenchmarkId::new("simd", dim), &(&lhs, &rhs), |b, input| {
-            b.iter(|| unsafe { dot_product(input.0, input.1) })
-        });
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        group.bench_with_input(
+            BenchmarkId::new("simd_avx2", dim),
+            &(&lhs, &rhs),
+            |b, input| b.iter(|| unsafe { dot_product(input.0, input.1) }),
+        );
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         if let Some(simd) = V3::try_new() {
-            group.bench_with_input(BenchmarkId::new("pulp", dim), &(&lhs, &rhs), |b, input| {
-                b.iter(|| simd::pulp::dot_product(simd, input.0, input.1))
-            });
+            group.bench_with_input(
+                BenchmarkId::new("pulp_avx2", dim),
+                &(&lhs, &rhs),
+                |b, input| b.iter(|| simd::pulp::dot_product(simd, input.0, input.1)),
+            );
+        }
+        #[cfg(target_arch = "aarch64")]
+        if let Some(simd) = Neon::try_new() {
+            group.bench_with_input(
+                BenchmarkId::new("pulp_neon", dim),
+                &(&lhs, &rhs),
+                |b, input| b.iter(|| gathers::simd::pulp::dot_product(simd, input.0, input.1)),
+            );
         }
     }
     group.finish();
@@ -157,15 +224,17 @@ pub fn binary_ip_benchmark(c: &mut Criterion) {
                 b.iter(|| binary_dot_product_native(input.0, input.1));
             },
         );
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         group.bench_with_input(
-            BenchmarkId::new("simd", dim * 64),
+            BenchmarkId::new("simd_avx2", dim * 64),
             &(&lhs, &rhs),
             |b, input| {
                 b.iter(|| unsafe { simd::binary_dot_product_simd(input.0, input.1) });
             },
         );
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         group.bench_with_input(
-            BenchmarkId::new("pulp", dim * 64),
+            BenchmarkId::new("pulp_avx2", dim * 64),
             &(&lhs, &rhs),
             |b, input| {
                 b.iter(|| simd::binary_dot_product(input.0, input.1));

--- a/benches/kmeans.rs
+++ b/benches/kmeans.rs
@@ -1,0 +1,83 @@
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use gathers::distance::Distance;
+use gathers::kmeans::{base_assign, base_assign_parallel, rabitq_assign_parallel};
+use gathers::rabitq::RaBitQ;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use rayon::prelude::*;
+
+fn assignment_benchmark(c: &mut Criterion) {
+    const NUM_VECTORS: usize = 4096;
+    const NUM_CENTROIDS: usize = 256;
+    const DIM: usize = 128;
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let vecs: Vec<f32> = (0..NUM_VECTORS * DIM).map(|_| rng.random()).collect();
+    let centroids: Vec<f32> = (0..NUM_CENTROIDS * DIM).map(|_| rng.random()).collect();
+    let mut labels = vec![0; NUM_VECTORS];
+    let rabitq = RaBitQ::new(&centroids, DIM);
+
+    let mut group = c.benchmark_group("assignment");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements((NUM_VECTORS * NUM_CENTROIDS) as u64));
+    group.bench_function("parallel_l2_4096x256x128", |b| {
+        b.iter(|| {
+            base_assign_parallel(
+                black_box(&vecs),
+                black_box(&centroids),
+                DIM,
+                Distance::SquaredEuclidean,
+                black_box(&mut labels),
+            )
+        })
+    });
+    group.bench_function("serial_dot_4096x256x128", |b| {
+        b.iter(|| {
+            base_assign(
+                black_box(&vecs),
+                black_box(&centroids),
+                DIM,
+                Distance::NegativeDotProduct,
+                black_box(&mut labels),
+            )
+        })
+    });
+    group.bench_function("parallel_dot_4096x256x128", |b| {
+        b.iter(|| {
+            base_assign_parallel(
+                black_box(&vecs),
+                black_box(&centroids),
+                DIM,
+                Distance::NegativeDotProduct,
+                black_box(&mut labels),
+            )
+        })
+    });
+    group.bench_function("rabitq_l2_4096x256x128", |b| {
+        b.iter(|| {
+            rabitq_assign_parallel(
+                black_box(&vecs),
+                black_box(&centroids),
+                DIM,
+                black_box(&mut labels),
+            )
+        })
+    });
+    group.bench_function("rabitq_per_query_4096x256x128", |b| {
+        b.iter(|| {
+            labels
+                .par_iter_mut()
+                .zip(vecs.par_chunks_exact(DIM))
+                .for_each(|(label, query)| {
+                    *label = rabitq.retrieve_top_one(black_box(query)) as u32;
+                })
+        })
+    });
+    group.bench_function("rabitq_batch_4096x256x128", |b| {
+        b.iter(|| rabitq.retrieve_top_one_batch(black_box(&vecs), DIM, black_box(&mut labels)))
+    });
+    group.finish();
+}
+
+criterion_group!(assignment_benches, assignment_benchmark);
+criterion_main!(assignment_benches);

--- a/benches/kmeans.rs
+++ b/benches/kmeans.rs
@@ -4,7 +4,9 @@ use gathers::kmeans::{base_assign, base_assign_parallel, rabitq_assign_parallel}
 use gathers::rabitq::RaBitQ;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use rayon::prelude::*;
+use rayon::prelude::{
+    IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator, ParallelSlice,
+};
 
 fn assignment_benchmark(c: &mut Criterion) {
     const NUM_VECTORS: usize = 4096;

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,7 +1,8 @@
 use core::f32;
 
 use numpy::{PyArray2, PyReadonlyArray1, PyReadonlyArray2};
-use pyo3::prelude::*;
+use pyo3::types::{PyModule, PyModuleMethods};
+use pyo3::{Bound, PyResult, pyfunction, pymodule, wrap_pyfunction};
 
 use gathers::distance::{Distance, argmin, squared_euclidean};
 use gathers::kmeans::{KMeans, rabitq_assign_parallel};

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -133,12 +133,25 @@ pub fn argmin(vec: &[f32]) -> usize {
 
 #[cfg(test)]
 mod test {
-    use rand::Rng;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
 
     use super::{
         argmin, l2_norm, l2_norm_native, native_argmin, native_dot_product,
         native_squared_euclidean, neg_dot_product, squared_euclidean,
     };
+
+    fn assert_f32_close(actual: f32, expected: f32, implementation: &str, dim: usize) {
+        const ABS_TOLERANCE: f32 = 1e-6;
+        const REL_TOLERANCE: f32 = 1e-5;
+
+        let diff = (actual - expected).abs();
+        let tolerance = ABS_TOLERANCE + REL_TOLERANCE * actual.abs().max(expected.abs());
+        assert!(
+            diff <= tolerance,
+            "{implementation} diff: {diff}, tolerance: {tolerance} for dim: {dim}"
+        );
+    }
 
     #[test]
     fn test_l2_squared_distance() {
@@ -166,23 +179,26 @@ mod test {
 
     #[test]
     fn test_dot_product_distance() {
-        let mut rng = rand::rng();
+        let mut rng = StdRng::seed_from_u64(42);
         for _ in 0..100 {
             for dim in [4, 12, 64, 70, 78].into_iter() {
                 let lhs = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();
                 let rhs = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();
 
-                let diff = neg_dot_product(&lhs, &rhs) + native_dot_product(&lhs, &rhs);
-                assert!(diff.abs() < 1e-5, "pulp diff: {diff} for dim: {dim}");
+                let expected = native_dot_product(&lhs, &rhs);
+                assert_f32_close(-neg_dot_product(&lhs, &rhs), expected, "pulp", dim);
 
                 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
                 {
                     if !is_x86_feature_detected!("avx2") {
                         continue;
                     }
-                    let diff = unsafe { crate::simd::dot_product(&lhs, &rhs) }
-                        - native_dot_product(&lhs, &rhs);
-                    assert!(diff.abs() < 1e-5, "simd diff: {diff} for dim: {dim}");
+                    assert_f32_close(
+                        unsafe { crate::simd::dot_product(&lhs, &rhs) },
+                        expected,
+                        "simd",
+                        dim,
+                    );
                 }
             }
         }

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use aligned_vec::AVec;
 use log::debug;
 use rand::Rng;
-use rayon::prelude::*;
+use rayon::prelude::{IndexedParallelIterator, ParallelIterator, ParallelSlice, ParallelSliceMut};
 
 use crate::distance::{Distance, squared_euclidean};
 use crate::rabitq::{RaBitQ, RaBitQWorkspace};

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -8,8 +8,8 @@ use log::debug;
 use rand::Rng;
 use rayon::prelude::*;
 
-use crate::distance::{Distance, argmin, neg_dot_product, squared_euclidean};
-use crate::rabitq::RaBitQ;
+use crate::distance::{Distance, squared_euclidean};
+use crate::rabitq::{RaBitQ, RaBitQWorkspace};
 use crate::sampling::subsample;
 use crate::utils::{as_continuous_vec, centroid_residual, normalize};
 
@@ -19,6 +19,61 @@ const MAX_POINTS_PER_CENTROID: usize = 256;
 const LARGE_CLUSTER_THRESHOLD: usize = 1 << 28;
 const RAYON_BLOCK_SIZE: usize = 64;
 
+struct AssignBlock<'a> {
+    vecs: &'a [f32],
+    centroids: &'a [f32],
+    dim: usize,
+    distance: Distance,
+    labels: &'a mut [u32],
+}
+
+impl pulp::WithSimd for AssignBlock<'_> {
+    type Output = ();
+
+    #[inline(always)]
+    fn with_simd<S: pulp::Simd>(self, simd: S) {
+        let Self {
+            vecs,
+            centroids,
+            dim,
+            distance,
+            labels,
+        } = self;
+
+        for (label, vector) in labels.iter_mut().zip(vecs.chunks_exact(dim)) {
+            let mut best_distance = f32::MAX;
+            let mut best_index = 0;
+            for (index, centroid) in centroids.chunks_exact(dim).enumerate() {
+                let candidate = match distance {
+                    Distance::SquaredEuclidean => {
+                        crate::simd::pulp::l2_squared_distance(simd, vector, centroid)
+                    }
+                    Distance::NegativeDotProduct => {
+                        -crate::simd::pulp::dot_product(simd, vector, centroid)
+                    }
+                };
+                if candidate < best_distance {
+                    best_distance = candidate;
+                    best_index = index;
+                }
+            }
+            *label = best_index as u32;
+        }
+    }
+}
+
+fn validate_assignment_inputs(vecs: &[f32], centroids: &[f32], dim: usize, labels: &[u32]) {
+    assert!(dim > 0, "dimension must be greater than zero");
+    assert_eq!(vecs.len() % dim, 0, "vectors must be complete");
+    assert_eq!(centroids.len() % dim, 0, "centroids must be complete");
+    assert_eq!(
+        labels.len(),
+        vecs.len() / dim,
+        "one label is required per vector"
+    );
+    assert!(!centroids.is_empty(), "at least one centroid is required");
+}
+
 /// Assign vectors to centroids in single thread.
 pub fn base_assign(
     vecs: &[f32],
@@ -27,25 +82,14 @@ pub fn base_assign(
     distance: Distance,
     labels: &mut [u32],
 ) {
-    let mut distances = vec![f32::MAX; centroids.len() / dim];
-    match distance {
-        Distance::NegativeDotProduct => {
-            for (i, vec) in vecs.chunks(dim).enumerate() {
-                for (j, centroid) in centroids.chunks(dim).enumerate() {
-                    distances[j] = neg_dot_product(vec, centroid);
-                }
-                labels[i] = argmin(&distances) as u32;
-            }
-        }
-        Distance::SquaredEuclidean => {
-            for (i, vec) in vecs.chunks(dim).enumerate() {
-                for (j, centroid) in centroids.chunks(dim).enumerate() {
-                    distances[j] = squared_euclidean(vec, centroid);
-                }
-                labels[i] = argmin(&distances) as u32;
-            }
-        }
-    }
+    validate_assignment_inputs(vecs, centroids, dim, labels);
+    pulp::Arch::new().dispatch(AssignBlock {
+        vecs,
+        centroids,
+        dim,
+        distance,
+        labels,
+    });
 }
 
 /// Assign vectors to centroids in multi-threads.
@@ -56,39 +100,19 @@ pub fn base_assign_parallel(
     distance: Distance,
     labels: &mut [u32],
 ) {
-    match distance {
-        Distance::NegativeDotProduct => {
-            let mut distances = vec![f32::MAX; centroids.len() / dim];
-            for (i, vec) in vecs.chunks(dim).enumerate() {
-                for (j, centroid) in centroids.chunks(dim).enumerate() {
-                    distances[j] = neg_dot_product(vec, centroid);
-                }
-                labels[i] = argmin(&distances) as u32;
-            }
-        }
-        Distance::SquaredEuclidean => {
-            // pre-compute the x**2 & y**2 for L2 distance
-            // let squared_x: Vec<f32> = vecs.chunks(dim).map(l2_norm).collect();
-            // let squared_y: Vec<f32> = centroids.chunks(dim).map(l2_norm).collect();
-
-            labels.copy_from_slice(
-                &vecs
-                    .par_chunks(dim * RAYON_BLOCK_SIZE)
-                    .flat_map(|vec| {
-                        let mut par_labels = vec![0; vec.len() / dim];
-                        let mut par_distances = vec![f32::MAX; centroids.len() / dim];
-                        for (i, v) in vec.chunks(dim).enumerate() {
-                            for (j, centroid) in centroids.chunks(dim).enumerate() {
-                                par_distances[j] = squared_euclidean(v, centroid);
-                            }
-                            par_labels[i] = argmin(&par_distances) as u32;
-                        }
-                        par_labels
-                    })
-                    .collect::<Vec<_>>(),
-            );
-        }
-    }
+    validate_assignment_inputs(vecs, centroids, dim, labels);
+    labels
+        .par_chunks_mut(RAYON_BLOCK_SIZE)
+        .zip(vecs.par_chunks(dim * RAYON_BLOCK_SIZE))
+        .for_each(|(labels, vecs)| {
+            pulp::Arch::new().dispatch(AssignBlock {
+                vecs,
+                centroids,
+                dim,
+                distance,
+                labels,
+            });
+        });
 }
 
 /// Assign vectors to centroids with RaBitQ in single thread.
@@ -97,9 +121,14 @@ pub fn rabitq_assign(vecs: &[f32], centroids: &[f32], dim: usize, labels: &mut [
     let rabitq = RaBitQ::new(centroids, dim);
     debug!("RaBitQ: build takes {} s", start.elapsed().as_secs_f32());
 
-    for (i, vec) in vecs.chunks(dim).enumerate() {
-        labels[i] = rabitq.retrieve_top_one(vec) as u32;
+    let mut workspace = RaBitQWorkspace::new(rabitq.dim());
+    let mut precise = 0;
+    for (label, vector) in labels.iter_mut().zip(vecs.chunks_exact(dim)) {
+        let (index, count) = rabitq.retrieve_top_one_with_workspace(vector, &mut workspace);
+        *label = index as u32;
+        precise += count;
     }
+    rabitq.update_metrics((labels.len() * rabitq.len()) as u64, precise);
 
     let (rough, precise) = rabitq.get_metrics();
     debug!(
@@ -115,17 +144,7 @@ pub fn rabitq_assign(vecs: &[f32], centroids: &[f32], dim: usize, labels: &mut [
 /// TODO: support dot product distance
 pub fn rabitq_assign_parallel(vecs: &[f32], centroids: &[f32], dim: usize, labels: &mut [u32]) {
     let rabitq = RaBitQ::new(centroids, dim);
-
-    labels.copy_from_slice(
-        &vecs
-            .par_chunks(dim * RAYON_BLOCK_SIZE)
-            .flat_map(|vec| {
-                vec.chunks(dim)
-                    .map(|v| rabitq.retrieve_top_one(v) as u32)
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>(),
-    );
+    rabitq.retrieve_top_one_batch(vecs, dim, labels);
 
     let (rough, precise) = rabitq.get_metrics();
     debug!(
@@ -139,7 +158,7 @@ pub fn rabitq_assign_parallel(vecs: &[f32], centroids: &[f32], dim: usize, label
 /// Update centroids to the mean of assigned vectors.
 pub fn update_centroids(vecs: &[f32], centroids: &mut [f32], dim: usize, labels: &[u32]) -> f32 {
     let mut means = vec![0.0; centroids.len()];
-    let mut elements = vec![0; centroids.len() / dim];
+    let mut elements: Vec<usize> = vec![0; centroids.len() / dim];
     for (i, vec) in vecs.chunks(dim).enumerate() {
         let label = labels[i] as usize;
         elements[label] += 1;
@@ -148,50 +167,57 @@ pub fn update_centroids(vecs: &[f32], centroids: &mut [f32], dim: usize, labels:
             .zip(vec.iter())
             .for_each(|(m, &v)| *m += v);
     }
-    let diff = squared_euclidean(centroids, &means);
-
     let mut zero_count = 0;
+    for i in 0..elements.len() {
+        if elements[i] != 0 {
+            let divider = (elements[i] as f32).recip();
+            means[i * dim..(i + 1) * dim]
+                .iter_mut()
+                .for_each(|value| *value *= divider);
+        }
+    }
+
     for i in 0..elements.len() {
         if elements[i] == 0 {
             // need to split another cluster to fill this empty cluster
             zero_count += 1;
-            let mut target = 0;
             let mut rng = rand::rng();
-            let base = 1.0 / (vecs.len() / dim - labels.len()) as f32;
-            loop {
-                let p = (elements[target] - 1) as f32 * base;
-                if rng.random::<f32>() < p {
+            let total_weight: usize = elements.iter().map(|&count| count.saturating_sub(1)).sum();
+            let mut sample = rng.random_range(0..total_weight);
+            let mut target = 0;
+            for (candidate, &count) in elements.iter().enumerate() {
+                let weight = count.saturating_sub(1);
+                if sample < weight {
+                    target = candidate;
                     break;
                 }
-                target = (target + 1) % labels.len();
+                sample -= weight;
             }
             debug!("split cluster {target} to fill empty cluster {i}");
             if i < target {
-                let (left, right) = centroids.split_at_mut(target * dim);
+                let (left, right) = means.split_at_mut(target * dim);
                 left[i * dim..(i + 1) * dim].copy_from_slice(&right[..dim]);
             } else {
-                let (left, right) = centroids.split_at_mut(i * dim);
+                let (left, right) = means.split_at_mut(i * dim);
                 right[..dim].copy_from_slice(&left[target * dim..(target + 1) * dim]);
             }
             // small symmetric perturbation
             for j in 0..dim {
                 if j % 2 == 0 {
-                    centroids[i * dim + j] *= 1.0 + EPS;
-                    centroids[target * dim + j] *= 1.0 - EPS;
+                    means[i * dim + j] *= 1.0 + EPS;
+                    means[target * dim + j] *= 1.0 - EPS;
                 } else {
-                    centroids[i * dim + j] *= 1.0 - EPS;
-                    centroids[target * dim + j] *= 1.0 + EPS;
+                    means[i * dim + j] *= 1.0 - EPS;
+                    means[target * dim + j] *= 1.0 + EPS;
                 }
             }
             // update elements
             elements[i] = elements[target] / 2;
             elements[target] -= elements[i];
         }
-        let divider = (elements[i] as f32).recip();
-        for j in i * dim..(i + 1) * dim {
-            centroids[j] = means[j] * divider;
-        }
     }
+    let diff = squared_euclidean(centroids, &means);
+    centroids.copy_from_slice(&means);
     if zero_count != 0 {
         debug!("fixed {zero_count} empty clusters");
     }
@@ -294,11 +320,13 @@ impl KMeans {
             centroids.chunks_mut(dim).for_each(normalize);
         }
 
-        let mut labels: Vec<u32> = vec![0; num];
+        let training_num = vecs.len() / dim;
+        let mut labels: Vec<u32> = vec![0; training_num];
         debug!("start training");
         for i in 0..self.max_iter {
             let start_time = Instant::now();
-            if self.distance == Distance::NegativeDotProduct || num * dim <= LARGE_CLUSTER_THRESHOLD
+            if self.distance == Distance::NegativeDotProduct
+                || training_num * dim <= LARGE_CLUSTER_THRESHOLD
             {
                 #[cfg(feature = "perf")]
                 base_assign(&vecs, &centroids, dim, self.distance, &mut labels);
@@ -329,7 +357,7 @@ impl KMeans {
 mod test {
     use rand::Rng;
 
-    use super::{KMeans, base_assign, rabitq_assign};
+    use super::{KMeans, base_assign, base_assign_parallel, rabitq_assign, update_centroids};
     use crate::distance::{Distance, argmin, squared_euclidean};
     use crate::utils::as_continuous_vec;
 
@@ -384,5 +412,50 @@ mod test {
                 "round: {r}, match rate: {match_rate}"
             );
         }
+    }
+
+    #[test]
+    fn test_parallel_assignment_matches_single_thread() {
+        let mut rng = rand::rng();
+        let dim = 32;
+        let vecs = (0..257 * dim)
+            .map(|_| rng.random::<f32>())
+            .collect::<Vec<_>>();
+        let centroids = (0..17 * dim)
+            .map(|_| rng.random::<f32>())
+            .collect::<Vec<_>>();
+
+        for distance in [Distance::SquaredEuclidean, Distance::NegativeDotProduct] {
+            let mut expected = vec![0; 257];
+            let mut actual = vec![0; 257];
+            base_assign(&vecs, &centroids, dim, distance, &mut expected);
+            base_assign_parallel(&vecs, &centroids, dim, distance, &mut actual);
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn test_update_centroids_returns_distance_to_new_means() {
+        let vecs = vec![0.0, 0.0, 2.0, 2.0];
+        let labels = vec![0, 0, 1, 1];
+        let mut centroids = vec![0.0, 4.0];
+
+        let diff = update_centroids(&vecs, &mut centroids, 1, &labels);
+
+        assert_eq!(centroids, vec![0.0, 2.0]);
+        assert_eq!(diff, 4.0);
+    }
+
+    #[test]
+    fn test_update_centroids_repairs_empty_cluster() {
+        let vecs = vec![2.0, 2.0, 2.0, 2.0];
+        let labels = vec![0, 0, 0, 0];
+        let mut centroids = vec![0.0, 10.0];
+
+        let diff = update_centroids(&vecs, &mut centroids, 1, &labels);
+
+        assert!(diff.is_finite());
+        assert!(centroids.iter().all(|value| (*value - 2.0).abs() < 0.01));
+        assert_ne!(centroids[0], centroids[1]);
     }
 }

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -165,69 +165,83 @@ pub fn rabitq_assign_parallel(vecs: &[f32], centroids: &[f32], dim: usize, label
 
 /// Update centroids to the mean of assigned vectors.
 pub fn update_centroids(vecs: &[f32], centroids: &mut [f32], dim: usize, labels: &[u32]) -> f32 {
+    validate_assignment_inputs(vecs, centroids, dim, labels);
+    let num_centroids = centroids.len() / dim;
+    assert!(
+        labels.len() >= num_centroids,
+        "number of vectors must be at least the number of centroids"
+    );
+    assert!(
+        labels.iter().all(|&label| (label as usize) < num_centroids),
+        "labels must reference an existing centroid"
+    );
+
     let mut means = vec![0.0; centroids.len()];
-    let mut elements: Vec<usize> = vec![0; centroids.len() / dim];
+    let mut cluster_sizes = vec![0usize; num_centroids];
     for (i, vec) in vecs.chunks(dim).enumerate() {
         let label = labels[i] as usize;
-        elements[label] += 1;
+        cluster_sizes[label] += 1;
         means[label * dim..(label + 1) * dim]
             .iter_mut()
             .zip(vec.iter())
             .for_each(|(m, &v)| *m += v);
     }
-    let mut zero_count = 0;
-    for i in 0..elements.len() {
-        if elements[i] != 0 {
-            let divider = (elements[i] as f32).recip();
+    let mut empty_cluster_count = 0;
+    for i in 0..cluster_sizes.len() {
+        if cluster_sizes[i] != 0 {
+            let divider = (cluster_sizes[i] as f32).recip();
             means[i * dim..(i + 1) * dim]
                 .iter_mut()
                 .for_each(|value| *value *= divider);
         }
     }
 
-    for i in 0..elements.len() {
-        if elements[i] == 0 {
+    for empty_cluster in 0..cluster_sizes.len() {
+        if cluster_sizes[empty_cluster] == 0 {
             // need to split another cluster to fill this empty cluster
-            zero_count += 1;
+            empty_cluster_count += 1;
             let mut rng = rand::rng();
-            let total_weight: usize = elements.iter().map(|&count| count.saturating_sub(1)).sum();
-            let mut sample = rng.random_range(0..total_weight);
-            let mut target = 0;
-            for (candidate, &count) in elements.iter().enumerate() {
-                let weight = count.saturating_sub(1);
-                if sample < weight {
-                    target = candidate;
+            let total_weight: usize = cluster_sizes
+                .iter()
+                .map(|&size| size.saturating_sub(1))
+                .sum();
+            let mut donor_sample = rng.random_range(0..total_weight);
+            let mut donor_cluster = 0;
+            for (candidate, &size) in cluster_sizes.iter().enumerate() {
+                let donor_weight = size.saturating_sub(1);
+                if donor_sample < donor_weight {
+                    donor_cluster = candidate;
                     break;
                 }
-                sample -= weight;
+                donor_sample -= donor_weight;
             }
-            debug!("split cluster {target} to fill empty cluster {i}");
-            if i < target {
-                let (left, right) = means.split_at_mut(target * dim);
-                left[i * dim..(i + 1) * dim].copy_from_slice(&right[..dim]);
+            debug!("split cluster {donor_cluster} to fill empty cluster {empty_cluster}");
+            if empty_cluster < donor_cluster {
+                let (left, right) = means.split_at_mut(donor_cluster * dim);
+                left[empty_cluster * dim..(empty_cluster + 1) * dim].copy_from_slice(&right[..dim]);
             } else {
-                let (left, right) = means.split_at_mut(i * dim);
-                right[..dim].copy_from_slice(&left[target * dim..(target + 1) * dim]);
+                let (left, right) = means.split_at_mut(empty_cluster * dim);
+                right[..dim].copy_from_slice(&left[donor_cluster * dim..(donor_cluster + 1) * dim]);
             }
             // small symmetric perturbation
             for j in 0..dim {
                 if j % 2 == 0 {
-                    means[i * dim + j] *= 1.0 + EPS;
-                    means[target * dim + j] *= 1.0 - EPS;
+                    means[empty_cluster * dim + j] *= 1.0 + EPS;
+                    means[donor_cluster * dim + j] *= 1.0 - EPS;
                 } else {
-                    means[i * dim + j] *= 1.0 - EPS;
-                    means[target * dim + j] *= 1.0 + EPS;
+                    means[empty_cluster * dim + j] *= 1.0 - EPS;
+                    means[donor_cluster * dim + j] *= 1.0 + EPS;
                 }
             }
-            // update elements
-            elements[i] = elements[target] / 2;
-            elements[target] -= elements[i];
+            // update cluster sizes
+            cluster_sizes[empty_cluster] = cluster_sizes[donor_cluster] / 2;
+            cluster_sizes[donor_cluster] -= cluster_sizes[empty_cluster];
         }
     }
     let diff = squared_euclidean(centroids, &means);
     centroids.copy_from_slice(&means);
-    if zero_count != 0 {
-        debug!("fixed {zero_count} empty clusters");
+    if empty_cluster_count != 0 {
+        debug!("fixed {empty_cluster_count} empty clusters");
     }
     diff
 }
@@ -235,7 +249,7 @@ pub fn update_centroids(vecs: &[f32], centroids: &mut [f32], dim: usize, labels:
 /// K-means clustering algorithm.
 #[derive(Debug)]
 pub struct KMeans {
-    n_cluster: u32,
+    num_clusters: u32,
     max_iter: u32,
     tolerance: f32,
     distance: Distance,
@@ -246,7 +260,7 @@ pub struct KMeans {
 impl Default for KMeans {
     fn default() -> Self {
         Self {
-            n_cluster: 8,
+            num_clusters: 8,
             max_iter: 25,
             tolerance: 1e-4,
             distance: Distance::default(),
@@ -261,20 +275,20 @@ impl KMeans {
     ///
     /// # Arguments
     ///
-    /// * `n_cluster` - number of clusters, recommend to be a number in [sqrt(n) * 4, sqrt(n) * 8]
+    /// * `num_clusters` - number of clusters, recommend to be a number in [sqrt(n) * 4, sqrt(n) * 8]
     /// * `max_iter` - max number of iterations
     /// * `tolerance` - convergence tolerance, stop when the diff is less than this value
     /// * `distance` - distance metric
     /// * `use_residual` - use residual for more accurate L2 distance computations, only work for L2
     pub fn new(
-        n_cluster: u32,
+        num_clusters: u32,
         max_iter: u32,
         tolerance: f32,
         distance: Distance,
         use_residual: bool,
     ) -> Self {
-        if n_cluster < 1 {
-            panic!("n_cluster must be greater than 0");
+        if num_clusters < 1 {
+            panic!("num_clusters must be greater than 0");
         }
         if max_iter < 1 {
             panic!("max_iter must be greater than 0");
@@ -283,7 +297,7 @@ impl KMeans {
             panic!("tolerance must be greater than 0.0");
         }
         Self {
-            n_cluster,
+            num_clusters,
             max_iter,
             tolerance,
             distance,
@@ -294,20 +308,21 @@ impl KMeans {
 
     /// Fit the KMeans configurations to the given vectors and return the centroids.
     pub fn fit(&self, mut vecs: AVec<f32>, dim: usize) -> AVec<f32> {
-        let num = vecs.len() / dim;
+        let num_vectors = vecs.len() / dim;
 
-        // auto-config the `n_cluster` if it's initialized with `default()`
-        let n_cluster = match self.use_default_config {
-            true => (((num as f32).sqrt() as u32) * 4).min((num / MIN_POINTS_PER_CENTROID) as u32),
-            false => self.n_cluster,
+        // auto-config `num_clusters` when initialized with `default()`
+        let num_clusters = match self.use_default_config {
+            true => (((num_vectors as f32).sqrt() as u32) * 4)
+                .min((num_vectors / MIN_POINTS_PER_CENTROID) as u32),
+            false => self.num_clusters,
         };
-        debug!("num of points: {num}, num of clusters: {n_cluster}");
+        debug!("num of points: {num_vectors}, num of clusters: {num_clusters}");
 
-        if num < n_cluster as usize {
-            panic!("number of samples must be greater than n_cluster");
+        if num_vectors < num_clusters as usize {
+            panic!("number of samples must be greater than num_clusters");
         }
-        if num < n_cluster as usize * MIN_POINTS_PER_CENTROID {
-            panic!("too few samples for n_cluster");
+        if num_vectors < num_clusters as usize * MIN_POINTS_PER_CENTROID {
+            panic!("too few samples for num_clusters");
         }
 
         // use residual for more accurate L2 distance computations
@@ -317,13 +332,13 @@ impl KMeans {
         }
 
         // subsample
-        if num > MAX_POINTS_PER_CENTROID * n_cluster as usize {
-            let n_sample = MAX_POINTS_PER_CENTROID * n_cluster as usize;
+        if num_vectors > MAX_POINTS_PER_CENTROID * num_clusters as usize {
+            let n_sample = MAX_POINTS_PER_CENTROID * num_clusters as usize;
             debug!("subsample to {n_sample} points");
             vecs = as_continuous_vec(&subsample(n_sample, &vecs, dim));
         }
 
-        let mut centroids = as_continuous_vec(&subsample(n_cluster as usize, &vecs, dim));
+        let mut centroids = as_continuous_vec(&subsample(num_clusters as usize, &vecs, dim));
         if self.distance == Distance::NegativeDotProduct {
             centroids.chunks_mut(dim).for_each(normalize);
         }
@@ -392,12 +407,12 @@ mod test {
                 labels[i] = argmin(&distances) as u32;
             }
 
-            let continue_vecs = as_continuous_vec(&vecs);
+            let flattened_vecs = as_continuous_vec(&vecs);
 
             // check the base assignment
             let mut base_labels = vec![0; n];
             base_assign(
-                &continue_vecs,
+                &flattened_vecs,
                 &centroids,
                 dim,
                 Distance::SquaredEuclidean,
@@ -407,7 +422,7 @@ mod test {
 
             // check the rabitq assignment
             let mut rabitq_labels = vec![0; n];
-            rabitq_assign(&continue_vecs, &centroids, dim, &mut rabitq_labels);
+            rabitq_assign(&flattened_vecs, &centroids, dim, &mut rabitq_labels);
             let mut match_count = 0;
             for i in 0..n {
                 if labels[i] == rabitq_labels[i] {
@@ -459,6 +474,13 @@ mod test {
 
         assert_eq!(centroids, vec![0.0, 2.0]);
         assert_eq!(diff, 4.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "number of vectors must be at least the number of centroids")]
+    fn test_update_centroids_rejects_more_centroids_than_vectors() {
+        let mut centroids = vec![0.0, 1.0];
+        update_centroids(&[0.0], &mut centroids, 1, &[0]);
     }
 
     #[test]

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -62,9 +62,13 @@ impl pulp::WithSimd for AssignBlock<'_> {
     }
 }
 
-fn validate_assignment_inputs(vecs: &[f32], centroids: &[f32], dim: usize, labels: &[u32]) {
+fn validate_vectors(vecs: &[f32], dim: usize) {
     assert!(dim > 0, "dimension must be greater than zero");
     assert_eq!(vecs.len() % dim, 0, "vectors must be complete");
+}
+
+fn validate_assignment_inputs(vecs: &[f32], centroids: &[f32], dim: usize, labels: &[u32]) {
+    validate_vectors(vecs, dim);
     assert_eq!(centroids.len() % dim, 0, "centroids must be complete");
     assert_eq!(
         labels.len(),
@@ -308,6 +312,9 @@ impl KMeans {
 
     /// Fit the KMeans configurations to the given vectors and return the centroids.
     pub fn fit(&self, mut vecs: AVec<f32>, dim: usize) -> AVec<f32> {
+        validate_vectors(&vecs, dim);
+        assert!(!vecs.is_empty(), "at least one vector is required");
+
         let num_vectors = vecs.len() / dim;
 
         // auto-config `num_clusters` when initialized with `default()`
@@ -383,6 +390,25 @@ mod test {
     use super::{KMeans, base_assign, base_assign_parallel, rabitq_assign, update_centroids};
     use crate::distance::{Distance, argmin, squared_euclidean};
     use crate::utils::as_continuous_vec;
+
+    #[test]
+    #[should_panic(expected = "dimension must be greater than zero")]
+    fn test_fit_rejects_zero_dimension() {
+        KMeans::default().fit(as_continuous_vec(&[vec![1.0]]), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "vectors must be complete")]
+    fn test_fit_rejects_incomplete_vectors() {
+        KMeans::default().fit(as_continuous_vec(&[vec![1.0, 2.0, 3.0]]), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one vector is required")]
+    fn test_fit_rejects_empty_input() {
+        let vecs: Vec<Vec<f32>> = Vec::new();
+        KMeans::default().fit(as_continuous_vec(&vecs), 1);
+    }
 
     #[test]
     fn test_kmeans() {

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -117,6 +117,8 @@ pub fn base_assign_parallel(
 
 /// Assign vectors to centroids with RaBitQ in single thread.
 pub fn rabitq_assign(vecs: &[f32], centroids: &[f32], dim: usize, labels: &mut [u32]) {
+    validate_assignment_inputs(vecs, centroids, dim, labels);
+
     let start = Instant::now();
     let rabitq = RaBitQ::new(centroids, dim);
     debug!("RaBitQ: build takes {} s", start.elapsed().as_secs_f32());
@@ -128,7 +130,11 @@ pub fn rabitq_assign(vecs: &[f32], centroids: &[f32], dim: usize, labels: &mut [
         *label = index as u32;
         precise += count;
     }
-    rabitq.update_metrics((labels.len() * rabitq.len()) as u64, precise);
+    let rough = u64::try_from(labels.len())
+        .expect("label count exceeds u64")
+        .checked_mul(u64::try_from(rabitq.len()).expect("centroid count exceeds u64"))
+        .expect("comparison count exceeds u64");
+    rabitq.update_metrics(rough, precise);
 
     let (rough, precise) = rabitq.get_metrics();
     debug!(
@@ -143,6 +149,8 @@ pub fn rabitq_assign(vecs: &[f32], centroids: &[f32], dim: usize, labels: &mut [
 ///
 /// TODO: support dot product distance
 pub fn rabitq_assign_parallel(vecs: &[f32], centroids: &[f32], dim: usize, labels: &mut [u32]) {
+    validate_assignment_inputs(vecs, centroids, dim, labels);
+
     let rabitq = RaBitQ::new(centroids, dim);
     rabitq.retrieve_top_one_batch(vecs, dim, labels);
 
@@ -432,6 +440,13 @@ mod test {
             base_assign_parallel(&vecs, &centroids, dim, distance, &mut actual);
             assert_eq!(actual, expected);
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "vectors must be complete")]
+    fn test_rabitq_assignment_rejects_incomplete_vectors() {
+        let mut labels = [0];
+        rabitq_assign(&[0.0, 1.0, 2.0], &[0.0, 1.0], 2, &mut labels);
     }
 
     #[test]

--- a/src/rabitq.rs
+++ b/src/rabitq.rs
@@ -337,6 +337,7 @@ pub struct RaBitQ {
     factors: Vec<Factor>,
     binary_vec: Vec<u64>,
     idx: Vec<usize>,
+    input_dim: usize,
     dim: usize,
     metrics: Metrics,
 }
@@ -420,6 +421,7 @@ impl RaBitQ {
             binary_vec,
             factors,
             idx,
+            input_dim: dim,
             dim: dim_pad,
             metrics: Metrics::default(),
         }
@@ -439,6 +441,10 @@ impl RaBitQ {
     /// processes its queries.
     pub fn retrieve_top_one_batch(&self, queries: &[f32], dim: usize, labels: &mut [u32]) {
         assert!(dim > 0, "dimension must be greater than zero");
+        assert_eq!(
+            dim, self.input_dim,
+            "query dimension must match the vector dimension"
+        );
         assert_eq!(queries.len() % dim, 0, "queries must be complete");
         assert_eq!(labels.len(), queries.len() / dim);
 
@@ -465,7 +471,11 @@ impl RaBitQ {
         query: &[f32],
         workspace: &mut RaBitQWorkspace,
     ) -> (usize, u64) {
-        assert_eq!(self.dim, query.len().div_ceil(64) * 64);
+        assert_eq!(
+            query.len(),
+            self.input_dim,
+            "query dimension must match the vector dimension"
+        );
         workspace.query.fill(0.0);
         workspace.query[..query.len()].copy_from_slice(query);
         workspace.binary.fill(0);
@@ -495,14 +505,14 @@ impl RaBitQ {
         let mut precise = 0;
         let dist_sqrt = yc_distance.sqrt();
         let offset = workspace.binary.len() / THETA_LOG_DIM;
-        for &i in self.idx.iter() {
-            let factor = &self.factors[i];
+        for (position, &original_index) in self.idx.iter().enumerate() {
+            let factor = &self.factors[position];
             let rough = factor.center_distance_square
                 + yc_distance
                 + lower_bound * factor.factor_ppc
                 + (2.0
                     * asymmetric_binary_dot_product(
-                        &self.binary_vec[i * offset..(i + 1) * offset],
+                        &self.binary_vec[position * offset..(position + 1) * offset],
                         &workspace.binary,
                     ) as f32
                     - scalar_sum as f32)
@@ -513,7 +523,7 @@ impl RaBitQ {
                 precise += 1;
                 let accurate = squared_euclidean(
                     self.centroids
-                        .col(i)
+                        .col(position)
                         .try_as_col_major()
                         .expect("col major")
                         .as_slice(),
@@ -521,7 +531,7 @@ impl RaBitQ {
                 );
                 if accurate < threshold {
                     threshold = accurate;
-                    min_index = self.idx[i];
+                    min_index = original_index;
                 }
             }
         }
@@ -548,6 +558,7 @@ mod test {
         SCALAR, THETA_LOG_DIM, binary_dot_product_native, scalar_quantize_native,
         vector_binarize_query_native,
     };
+    use crate::distance::squared_euclidean;
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     use crate::simd;
 
@@ -675,5 +686,29 @@ mod test {
         rabitq.retrieve_top_one_batch(&queries, dim, &mut actual);
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_retrieval_matches_brute_force_after_centroid_sorting() {
+        let dim = 64;
+        let values = [-30.0, -2.0, 0.0, 1.0, 8.0, 40.0];
+        let mut centroids = vec![0.0; values.len() * dim];
+        for (centroid, &value) in centroids.chunks_exact_mut(dim).zip(&values) {
+            centroid[0] = value;
+        }
+        let rabitq = RaBitQ::new(&centroids, dim);
+
+        assert_ne!(rabitq.idx, (0..values.len()).collect::<Vec<_>>());
+        for query in centroids.chunks_exact(dim) {
+            let expected = centroids
+                .chunks_exact(dim)
+                .enumerate()
+                .min_by(|(_, left), (_, right)| {
+                    squared_euclidean(left, query).total_cmp(&squared_euclidean(right, query))
+                })
+                .map(|(index, _)| index)
+                .unwrap();
+            assert_eq!(rabitq.retrieve_top_one(query), expected);
+        }
     }
 }

--- a/src/rabitq.rs
+++ b/src/rabitq.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use faer::{Col, Mat, MatRef, Row};
 use rand::Rng;
 use rand_distr::StandardNormal;
+use rayon::prelude::*;
 
 use crate::distance::squared_euclidean;
 
@@ -99,6 +100,46 @@ pub fn project(vec: &[f32], orthogonal: &MatRef<f32>) -> Col<f32> {
     }
 
     pulp::Arch::new().dispatch(Impl { vec, orthogonal })
+}
+
+#[inline]
+fn project_into(vec: &[f32], orthogonal: &MatRef<f32>, output: &mut [f32]) {
+    struct Impl<'a, 'b> {
+        vec: &'a [f32],
+        orthogonal: &'a MatRef<'b, f32>,
+        output: &'a mut [f32],
+    }
+
+    impl pulp::WithSimd for Impl<'_, '_> {
+        type Output = ();
+
+        #[inline(always)]
+        fn with_simd<S: pulp::Simd>(self, simd: S) {
+            let Self {
+                vec,
+                orthogonal,
+                output,
+            } = self;
+            for (i, value) in output.iter_mut().enumerate() {
+                *value = crate::simd::pulp::dot_product(
+                    simd,
+                    vec,
+                    orthogonal
+                        .col(i)
+                        .try_as_col_major()
+                        .expect("col major")
+                        .as_slice(),
+                );
+            }
+        }
+    }
+
+    assert_eq!(output.len(), orthogonal.ncols());
+    pulp::Arch::new().dispatch(Impl {
+        vec,
+        orthogonal,
+        output,
+    });
 }
 
 /// Get the min/max value of the residual of two vectors.
@@ -252,6 +293,26 @@ struct Metrics {
     pub precise: AtomicU64,
 }
 
+pub(crate) struct RaBitQWorkspace {
+    query: Vec<f32>,
+    projected: Vec<f32>,
+    quantized: Vec<u8>,
+    binary: Vec<u64>,
+    residual: Vec<f32>,
+}
+
+impl RaBitQWorkspace {
+    pub(crate) fn new(dim: usize) -> Self {
+        Self {
+            query: vec![0.0; dim],
+            projected: vec![0.0; dim],
+            quantized: vec![0; dim],
+            binary: vec![0; (dim * THETA_LOG_DIM).div_ceil(64)],
+            residual: vec![0.0; dim],
+        }
+    }
+}
+
 impl Metrics {
     pub fn update(&self, rough: u64, precise: u64) {
         self.rough.fetch_add(rough, Ordering::Relaxed);
@@ -279,6 +340,14 @@ pub struct RaBitQ {
 }
 
 impl RaBitQ {
+    pub(crate) fn dim(&self) -> usize {
+        self.dim
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.idx.len()
+    }
+
     /// Create a new RaBitQ instance.
     pub fn new(centroids: &[f32], dim: usize) -> Self {
         // init
@@ -356,83 +425,97 @@ impl RaBitQ {
 
     /// Retrieve the top-1 index.
     pub fn retrieve_top_one(&self, query: &[f32]) -> usize {
-        assert_eq!(self.dim, query.len().div_ceil(64) * 64);
-        let mut query_pad = query.to_vec();
-        if self.dim > query.len() {
-            query_pad.extend_from_slice(&vec![0.0; self.dim - query.len()]);
-        }
+        let mut workspace = RaBitQWorkspace::new(self.dim);
+        let (index, precise) = self.retrieve_top_one_with_workspace(query, &mut workspace);
+        self.metrics.update(self.idx.len() as u64, precise);
+        index
+    }
 
-        let projected = project(&query_pad, &self.orthogonal.as_ref());
-        let mut rough_distances = Vec::with_capacity(self.idx.len());
-        let mut quantized = vec![0u8; self.dim];
-        let mut binary = vec![0u64; (self.dim * THETA_LOG_DIM).div_ceil(64)];
-        let mut residual = vec![0.0; self.dim];
-        let projected_slice = projected.try_as_col_major().expect("col major").as_slice();
+    /// Retrieve the nearest centroid for a batch of queries in parallel.
+    ///
+    /// Workspaces are initialized by Rayon tasks and reused while each task
+    /// processes its queries.
+    pub fn retrieve_top_one_batch(&self, queries: &[f32], dim: usize, labels: &mut [u32]) {
+        assert!(dim > 0, "dimension must be greater than zero");
+        assert_eq!(queries.len() % dim, 0, "queries must be complete");
+        assert_eq!(labels.len(), queries.len() / dim);
+
+        let (rough, precise) = labels
+            .par_iter_mut()
+            .zip(queries.par_chunks_exact(dim))
+            .map_init(
+                || RaBitQWorkspace::new(self.dim),
+                |workspace, (label, query)| {
+                    let (index, precise) = self.retrieve_top_one_with_workspace(query, workspace);
+                    *label = index as u32;
+                    (self.len() as u64, precise)
+                },
+            )
+            .reduce(
+                || (0, 0),
+                |left, right| (left.0 + right.0, left.1 + right.1),
+            );
+        self.metrics.update(rough, precise);
+    }
+
+    pub(crate) fn retrieve_top_one_with_workspace(
+        &self,
+        query: &[f32],
+        workspace: &mut RaBitQWorkspace,
+    ) -> (usize, u64) {
+        assert_eq!(self.dim, query.len().div_ceil(64) * 64);
+        workspace.query.fill(0.0);
+        workspace.query[..query.len()].copy_from_slice(query);
+        workspace.binary.fill(0);
+
+        project_into(
+            &workspace.query,
+            &self.orthogonal.as_ref(),
+            &mut workspace.projected,
+        );
         let mean_slice = self.mean.try_as_row_major().expect("row major").as_slice();
-        let yc_distance = squared_euclidean(projected_slice, mean_slice);
+        let yc_distance = squared_euclidean(&workspace.projected, mean_slice);
 
         let (lower_bound, upper_bound) =
-            min_max_residual(&mut residual, projected_slice, mean_slice);
+            min_max_residual(&mut workspace.residual, &workspace.projected, mean_slice);
         let delta = (upper_bound - lower_bound) * SCALAR;
         let one_over_delta = delta.recip();
-        let scalar_sum = scalar_quantize(&mut quantized, &residual, lower_bound, one_over_delta);
-        vector_binarize_query(&quantized, &mut binary);
-        self.calculate_rough_distance(
-            yc_distance,
-            &binary,
+        let scalar_sum = scalar_quantize(
+            &mut workspace.quantized,
+            &workspace.residual,
             lower_bound,
-            scalar_sum as f32,
-            delta,
-            &mut rough_distances,
+            one_over_delta,
         );
-        self.rank(&rough_distances, &query_pad)
-    }
+        vector_binarize_query(&workspace.quantized, &mut workspace.binary);
 
-    fn calculate_rough_distance(
-        &self,
-        yc_distance_square: f32,
-        y_binary_vec: &[u64],
-        lower_bound: f32,
-        scalar_sum: f32,
-        delta: f32,
-        rough_distances: &mut Vec<(f32, usize)>,
-    ) {
-        let dist_sqrt = yc_distance_square.sqrt();
-        let offset = y_binary_vec.len() / THETA_LOG_DIM;
-        for &i in self.idx.iter() {
-            let factor = &self.factors[i];
-            rough_distances.push((
-                (factor.center_distance_square
-                    + yc_distance_square
-                    + lower_bound * factor.factor_ppc
-                    + (2.0
-                        * asymmetric_binary_dot_product(
-                            &self.binary_vec[i * offset..(i + 1) * offset],
-                            y_binary_vec,
-                        ) as f32
-                        - scalar_sum)
-                        * factor.factor_ip
-                        * delta
-                    - factor.error_bound * dist_sqrt),
-                i,
-            ));
-        }
-    }
-
-    fn rank(&self, rough_distances: &[(f32, usize)], query: &[f32]) -> usize {
         let mut threshold = f32::MAX;
         let mut min_index = 0;
-        let mut count = 0;
-        for &(rough, i) in rough_distances.iter() {
+        let mut precise = 0;
+        let dist_sqrt = yc_distance.sqrt();
+        let offset = workspace.binary.len() / THETA_LOG_DIM;
+        for &i in self.idx.iter() {
+            let factor = &self.factors[i];
+            let rough = factor.center_distance_square
+                + yc_distance
+                + lower_bound * factor.factor_ppc
+                + (2.0
+                    * asymmetric_binary_dot_product(
+                        &self.binary_vec[i * offset..(i + 1) * offset],
+                        &workspace.binary,
+                    ) as f32
+                    - scalar_sum as f32)
+                    * factor.factor_ip
+                    * delta
+                - factor.error_bound * dist_sqrt;
             if rough < threshold {
-                count += 1;
+                precise += 1;
                 let accurate = squared_euclidean(
                     self.centroids
                         .col(i)
                         .try_as_col_major()
                         .expect("col major")
                         .as_slice(),
-                    query,
+                    &workspace.query,
                 );
                 if accurate < threshold {
                     threshold = accurate;
@@ -440,9 +523,11 @@ impl RaBitQ {
                 }
             }
         }
-        self.metrics.update(rough_distances.len() as u64, count);
+        (min_index, precise)
+    }
 
-        min_index
+    pub(crate) fn update_metrics(&self, rough: u64, precise: u64) {
+        self.metrics.update(rough, precise);
     }
 
     /// Get the rough/precise metrics.
@@ -455,10 +540,13 @@ impl RaBitQ {
 mod test {
     use rand::Rng;
 
+    use super::{RaBitQ, min_max_residual, min_max_residual_native};
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     use super::{
-        SCALAR, THETA_LOG_DIM, binary_dot_product_native, min_max_residual,
-        min_max_residual_native, scalar_quantize_native, vector_binarize_query_native,
+        SCALAR, THETA_LOG_DIM, binary_dot_product_native, scalar_quantize_native,
+        vector_binarize_query_native,
     };
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     use crate::simd;
 
     #[test]
@@ -563,5 +651,27 @@ mod test {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_batch_retrieval_matches_individual_retrieval() {
+        let mut rng = rand::rng();
+        let dim = 64;
+        let centroids = (0..16 * dim)
+            .map(|_| rng.random::<f32>())
+            .collect::<Vec<_>>();
+        let queries = (0..128 * dim)
+            .map(|_| rng.random::<f32>())
+            .collect::<Vec<_>>();
+        let rabitq = RaBitQ::new(&centroids, dim);
+
+        let expected = queries
+            .chunks_exact(dim)
+            .map(|query| rabitq.retrieve_top_one(query) as u32)
+            .collect::<Vec<_>>();
+        let mut actual = vec![0; expected.len()];
+        rabitq.retrieve_top_one_batch(&queries, dim, &mut actual);
+
+        assert_eq!(actual, expected);
     }
 }

--- a/src/rabitq.rs
+++ b/src/rabitq.rs
@@ -336,7 +336,7 @@ pub struct RaBitQ {
     orthogonal: Mat<f32>,
     factors: Vec<Factor>,
     binary_vec: Vec<u64>,
-    idx: Vec<usize>,
+    sorted_to_original: Vec<usize>,
     input_dim: usize,
     dim: usize,
     metrics: Metrics,
@@ -348,7 +348,7 @@ impl RaBitQ {
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.idx.len()
+        self.sorted_to_original.len()
     }
 
     /// Create a new RaBitQ instance.
@@ -358,9 +358,9 @@ impl RaBitQ {
         assert!(!centroids.is_empty(), "at least one centroid is required");
 
         // init
-        let num = centroids.len() / dim;
+        let num_centroids = centroids.len() / dim;
         let dim_pad = dim.div_ceil(64) * 64;
-        let centroids_mat = Mat::from_fn(num, dim_pad, |i, j| match j < dim {
+        let centroids_mat = Mat::from_fn(num_centroids, dim_pad, |i, j| match j < dim {
             true => centroids[i * dim + j],
             false => 0.0,
         });
@@ -372,16 +372,16 @@ impl RaBitQ {
         let orthogonal = random.qr().compute_Q();
 
         let projected = &centroids_mat * &orthogonal;
-        let mut factors = vec![Factor::default(); num];
-        let mut xc_distances = vec![0.0; num];
-        let mut x_dot_product = vec![0.0; num];
-        let mut binary_vec = Vec::with_capacity(num);
-        let mut signed_vec = Vec::with_capacity(num);
+        let mut factors = vec![Factor::default(); num_centroids];
+        let mut xc_distances = vec![0.0; num_centroids];
+        let mut x_dot_product = vec![0.0; num_centroids];
+        let mut binary_vec = Vec::with_capacity(num_centroids);
+        let mut signed_vec = Vec::with_capacity(num_centroids);
         let mut mean = Row::zeros(dim_pad);
         for v in projected.row_iter() {
             mean += v;
         }
-        mean.iter_mut().for_each(|v| *v /= num as f32);
+        mean.iter_mut().for_each(|v| *v /= num_centroids as f32);
 
         // factors
         for (i, p) in projected.row_iter().enumerate() {
@@ -399,7 +399,7 @@ impl RaBitQ {
         }
 
         let error_base = 2.0 * EPSILON / (dim_pad as f32 - 1.0).sqrt();
-        for i in 0..num {
+        for i in 0..num_centroids {
             let xc_over_ip = xc_distances[i] / x_dot_product[i];
             let factor = &mut factors[i];
             factor.error_bound =
@@ -409,14 +409,25 @@ impl RaBitQ {
         }
 
         // sort by distances
-        let mut idx = xc_distances.iter().enumerate().collect::<Vec<_>>();
-        idx.sort_by(|&x, &y| x.1.partial_cmp(y.1).unwrap());
-        let idx = idx.into_iter().map(|(i, _)| i).collect::<Vec<_>>();
-        let binary_vec = idx.iter().flat_map(|&i| binary_vec[i].clone()).collect();
-        let factors: Vec<Factor> = idx.iter().map(|&i| factors[i]).collect();
-        let centroids_col_based = Mat::from_fn(num, dim_pad, |i, j| *centroids_mat.get(idx[i], j))
-            .transpose()
-            .to_owned();
+        let mut sorted_to_original = xc_distances.iter().enumerate().collect::<Vec<_>>();
+        sorted_to_original.sort_by(|&x, &y| x.1.partial_cmp(y.1).unwrap());
+        let sorted_to_original = sorted_to_original
+            .into_iter()
+            .map(|(original_index, _)| original_index)
+            .collect::<Vec<_>>();
+        let binary_vec = sorted_to_original
+            .iter()
+            .flat_map(|&original_index| binary_vec[original_index].clone())
+            .collect();
+        let factors: Vec<Factor> = sorted_to_original
+            .iter()
+            .map(|&original_index| factors[original_index])
+            .collect();
+        let centroids_col_based = Mat::from_fn(num_centroids, dim_pad, |sorted_index, j| {
+            *centroids_mat.get(sorted_to_original[sorted_index], j)
+        })
+        .transpose()
+        .to_owned();
 
         RaBitQ {
             centroids: centroids_col_based,
@@ -424,7 +435,7 @@ impl RaBitQ {
             mean,
             binary_vec,
             factors,
-            idx,
+            sorted_to_original,
             input_dim: dim,
             dim: dim_pad,
             metrics: Metrics::default(),
@@ -435,7 +446,8 @@ impl RaBitQ {
     pub fn retrieve_top_one(&self, query: &[f32]) -> usize {
         let mut workspace = RaBitQWorkspace::new(self.dim);
         let (index, precise) = self.retrieve_top_one_with_workspace(query, &mut workspace);
-        self.metrics.update(self.idx.len() as u64, precise);
+        self.metrics
+            .update(self.sorted_to_original.len() as u64, precise);
         index
     }
 
@@ -490,7 +502,7 @@ impl RaBitQ {
             &mut workspace.projected,
         );
         let mean_slice = self.mean.try_as_row_major().expect("row major").as_slice();
-        let yc_distance = squared_euclidean(&workspace.projected, mean_slice);
+        let query_center_distance_squared = squared_euclidean(&workspace.projected, mean_slice);
 
         let (lower_bound, upper_bound) =
             min_max_residual(&mut workspace.residual, &workspace.projected, mean_slice);
@@ -507,12 +519,12 @@ impl RaBitQ {
         let mut threshold = f32::MAX;
         let mut min_index = 0;
         let mut precise = 0;
-        let dist_sqrt = yc_distance.sqrt();
+        let query_center_distance = query_center_distance_squared.sqrt();
         let offset = workspace.binary.len() / THETA_LOG_DIM;
-        for (position, &original_index) in self.idx.iter().enumerate() {
+        for (position, &original_index) in self.sorted_to_original.iter().enumerate() {
             let factor = &self.factors[position];
             let rough = factor.center_distance_square
-                + yc_distance
+                + query_center_distance_squared
                 + lower_bound * factor.factor_ppc
                 + (2.0
                     * asymmetric_binary_dot_product(
@@ -522,7 +534,7 @@ impl RaBitQ {
                     - scalar_sum as f32)
                     * factor.factor_ip
                     * delta
-                - factor.error_bound * dist_sqrt;
+                - factor.error_bound * query_center_distance;
             if rough < threshold {
                 precise += 1;
                 let accurate = squared_euclidean(
@@ -708,7 +720,10 @@ mod test {
         }
         let rabitq = RaBitQ::new(&centroids, dim);
 
-        assert_ne!(rabitq.idx, (0..values.len()).collect::<Vec<_>>());
+        assert_ne!(
+            rabitq.sorted_to_original,
+            (0..values.len()).collect::<Vec<_>>()
+        );
         for query in centroids.chunks_exact(dim) {
             let expected = centroids
                 .chunks_exact(dim)

--- a/src/rabitq.rs
+++ b/src/rabitq.rs
@@ -353,6 +353,10 @@ impl RaBitQ {
 
     /// Create a new RaBitQ instance.
     pub fn new(centroids: &[f32], dim: usize) -> Self {
+        assert!(dim > 0, "dimension must be greater than zero");
+        assert_eq!(centroids.len() % dim, 0, "centroids must be complete");
+        assert!(!centroids.is_empty(), "at least one centroid is required");
+
         // init
         let num = centroids.len() / dim;
         let dim_pad = dim.div_ceil(64) * 64;
@@ -561,6 +565,12 @@ mod test {
     use crate::distance::squared_euclidean;
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     use crate::simd;
+
+    #[test]
+    #[should_panic(expected = "centroids must be complete")]
+    fn test_new_rejects_incomplete_centroids() {
+        RaBitQ::new(&[0.0, 1.0, 2.0], 2);
+    }
 
     #[test]
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]

--- a/src/rabitq.rs
+++ b/src/rabitq.rs
@@ -6,7 +6,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use faer::{Col, Mat, MatRef, Row};
 use rand::Rng;
 use rand_distr::StandardNormal;
-use rayon::prelude::*;
+use rayon::prelude::{
+    IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator, ParallelSlice,
+};
 
 use crate::distance::squared_euclidean;
 

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -23,13 +23,11 @@ where
         res.push(iteration.next().expect("iteration less than n_sample"));
     }
 
-    let mut i = n_sample;
-    for vec in iteration.by_ref() {
+    for (i, vec) in (n_sample..).zip(iteration.by_ref()) {
         let j = rng.random_range(0..=i);
         if j < n_sample {
             res[j] = vec;
         }
-        i += 1;
     }
 
     res

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -1,7 +1,9 @@
 //! Accelerate with SIMD.
 
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 use core::iter;
 
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 use crate::rabitq::THETA_LOG_DIM;
 
 pub mod pulp;


### PR DESCRIPTION
## Summary

- add AArch64/Neon support through `pulp` SIMD dispatch while retaining x86/AVX2 paths
- improve K-means assignment and RaBitQ batch retrieval by reusing SIMD workspaces across Rayon tasks
- fix sorted centroid indexing, validate assignment inputs, and make empty-cluster repair safer

## Benchmarks

Adds K-means benchmarks for serial, parallel, and RaBitQ assignment, and separates AVX2 and Neon SIMD results.

## Verification

Passed Rust tests, Clippy with warnings denied, AArch64 target tests, Python crate tests, and `git diff --check`.
