### PR TITLE
perf: reuse matrix workspace for k-means

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  GATHERS_BENCH_SEED: "42"
+  GATHERS_RANDOM_SEED: "42"
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -19,6 +19,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  GATHERS_BENCH_SEED: "42"
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,9 @@ identical.
 
 ## Benchmarks
 
-Benchmarks also generate fresh representative inputs intentionally. They measure performance over
+Local benchmarks generate fresh representative inputs intentionally. They measure performance over
 the input distribution rather than one permanently fixed sample; benchmark conclusions should be
-confirmed across multiple samples or runs. Input preparation and cloning belong in Criterion setup,
-outside the timed routine.
+confirmed across multiple samples or runs. CodSpeed sets `GATHERS_BENCH_SEED` so base and change
+measurements use the same input and K-means initialization. Set that variable locally to reproduce a
+CodSpeed workload. Input preparation and cloning belong in Criterion setup, outside the timed
+routine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ inputs that a single fixed dataset may miss. Each test prints its seed before us
 Reproduce a failure with the printed seed:
 
 ```console
-GATHERS_TEST_SEED=123456 cargo test test_name -- --nocapture
+GATHERS_RANDOM_SEED=123456 cargo test test_name -- --nocapture
 ```
 
 Keep targeted regression tests deterministic when a particular input is part of the regression.
@@ -20,7 +20,7 @@ identical.
 
 Local benchmarks generate fresh representative inputs intentionally. They measure performance over
 the input distribution rather than one permanently fixed sample; benchmark conclusions should be
-confirmed across multiple samples or runs. CodSpeed sets `GATHERS_BENCH_SEED` so base and change
+confirmed across multiple samples or runs. CodSpeed sets `GATHERS_RANDOM_SEED` so base and change
 measurements use the same input and K-means initialization. Set that variable locally to reproduce a
 CodSpeed workload. Input preparation and cloning belong in Criterion setup, outside the timed
 routine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+## Randomized tests
+
+Randomized correctness tests intentionally choose a fresh seed on each run so they can exercise
+inputs that a single fixed dataset may miss. Each test prints its seed before using a deterministic
+`StdRng`. Cargo includes captured stderr when a test fails.
+
+Reproduce a failure with the printed seed:
+
+```console
+GATHERS_TEST_SEED=123456 cargo test test_name -- --nocapture
+```
+
+Keep targeted regression tests deterministic when a particular input is part of the regression.
+Do not replace the shared randomized-test helper with a fixed seed merely to make successful runs
+identical.
+
+## Benchmarks
+
+Benchmarks also generate fresh representative inputs intentionally. They measure performance over
+the input distribution rather than one permanently fixed sample; benchmark conclusions should be
+confirmed across multiple samples or runs. Input preparation and cloning belong in Criterion setup,
+outside the timed routine.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -93,6 +93,26 @@ name = "bytemuck"
 version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
@@ -226,6 +246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "defer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
+
+[[package]]
 name = "dyn-stack"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +265,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "env_filter"
@@ -276,7 +314,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -287,7 +325,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -307,6 +345,7 @@ dependencies = [
  "nano-gemm",
  "num-complex",
  "num-traits",
+ "private-gemm-x86",
  "pulp",
  "reborrow",
 ]
@@ -319,7 +358,7 @@ checksum = "9d0a255d1442b5825c61812a7eafda9034ec53d969c98555251085e148428e6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -368,6 +407,7 @@ dependencies = [
  "gemm-c32",
  "gemm-c64",
  "gemm-common",
+ "gemm-f16",
  "gemm-f32",
  "gemm-f64",
  "num-complex",
@@ -415,12 +455,31 @@ checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
 dependencies = [
  "bytemuck",
  "dyn-stack",
+ "half",
  "libm",
  "num-complex",
  "num-traits",
  "once_cell",
  "paste",
  "pulp",
+ "raw-cpuid",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
  "raw-cpuid",
  "seq-macro",
 ]
@@ -479,15 +538,34 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
+ "num-traits",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+
+[[package]]
+name = "interpol"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb58032ba748f4010d15912a1855a8a0b1ba9eaad3395b0c171c09b3b356ae50"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "is-terminal"
@@ -538,7 +616,7 @@ checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -693,6 +771,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +848,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "private-gemm-x86"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af8c3e5087969c323f667ccb4b789fa0954f5aa650550e38e81cf9108be21b5"
+dependencies = [
+ "defer",
+ "interpol",
+ "num_cpus",
+ "raw-cpuid",
 ]
 
 [[package]]
@@ -965,7 +1065,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -982,6 +1082,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
@@ -989,6 +1100,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1054,7 +1199,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -1076,7 +1221,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1208,5 +1353,5 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ dependencies = [
  "rand",
  "rand_distr",
  "rayon",
+ "seed-rand",
 ]
 
 [[package]]
@@ -1040,6 +1041,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "seed-rand"
+version = "0.0.0"
+dependencies = [
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["crates/seed_rand"]
+exclude = ["python"]
 resolver = "3"
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.85"
 aligned-vec = "0.6.4"
 argh = "0.1.13"
 bytemuck = "1.22.0"
-faer = { version = "0.22.6", default-features = false, features = ["linalg"] }
+faer = { version = "0.22.6", default-features = false, features = ["linalg", "std"] }
 log = "0.4.27"
 logforth = "0.24.0"
 num-traits = "0.2.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = ["crates/seed_rand"]
+resolver = "3"
+
 [package]
 name = "gathers"
 version = "0.3.1"
@@ -42,6 +46,7 @@ perf = []
 
 [dev-dependencies]
 criterion = "0.5.1"
+seed-rand = { path = "crates/seed_rand" }
 
 [[bench]]
 name = "bench"

--- a/benches/kmeans.rs
+++ b/benches/kmeans.rs
@@ -2,17 +2,31 @@ use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, cr
 use gathers::distance::Distance;
 use gathers::kmeans::{KMeans, base_assign, base_assign_parallel, rabitq_assign_parallel};
 use gathers::rabitq::RaBitQ;
-use rand::Rng;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 use rayon::prelude::{
     IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator, ParallelSlice,
 };
+
+const BENCH_SEED_ENV: &str = "GATHERS_BENCH_SEED";
+
+fn benchmark_seed() -> u64 {
+    std::env::var(BENCH_SEED_ENV).map_or_else(
+        |_| rand::rng().random(),
+        |value| {
+            value
+                .parse()
+                .unwrap_or_else(|_| panic!("{BENCH_SEED_ENV} must be an unsigned 64-bit integer"))
+        },
+    )
+}
 
 fn assignment_benchmark(c: &mut Criterion) {
     const NUM_VECTORS: usize = 4096;
     const NUM_CENTROIDS: usize = 256;
     const DIM: usize = 128;
 
-    let mut rng = rand::rng();
+    let mut rng = StdRng::seed_from_u64(benchmark_seed());
     let vecs: Vec<f32> = (0..NUM_VECTORS * DIM).map(|_| rng.random()).collect();
     let centroids: Vec<f32> = (0..NUM_CENTROIDS * DIM).map(|_| rng.random()).collect();
     let mut labels = vec![0; NUM_VECTORS];
@@ -86,7 +100,8 @@ fn kmeans_benchmark(c: &mut Criterion) {
     const DIM: usize = 128;
     const ITERATIONS: usize = 5;
 
-    let mut rng = rand::rng();
+    let seed = benchmark_seed();
+    let mut rng = StdRng::seed_from_u64(seed);
     let source: Vec<f32> = (0..NUM_VECTORS * DIM).map(|_| rng.random()).collect();
     let vecs = gathers::utils::as_continuous_vec(&[source]);
     let l2_kmeans = KMeans::new(
@@ -95,14 +110,16 @@ fn kmeans_benchmark(c: &mut Criterion) {
         f32::MIN_POSITIVE,
         Distance::SquaredEuclidean,
         false,
-    );
+    )
+    .seed(seed);
     let dot_kmeans = KMeans::new(
         NUM_CENTROIDS as u32,
         ITERATIONS as u32,
         f32::MIN_POSITIVE,
         Distance::NegativeDotProduct,
         false,
-    );
+    )
+    .seed(seed);
 
     let mut group = c.benchmark_group("kmeans");
     group.sample_size(20);

--- a/benches/kmeans.rs
+++ b/benches/kmeans.rs
@@ -1,9 +1,8 @@
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use gathers::distance::Distance;
-use gathers::kmeans::{base_assign, base_assign_parallel, rabitq_assign_parallel};
+use gathers::kmeans::{KMeans, base_assign, base_assign_parallel, rabitq_assign_parallel};
 use gathers::rabitq::RaBitQ;
-use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 use rayon::prelude::{
     IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator, ParallelSlice,
 };
@@ -13,7 +12,7 @@ fn assignment_benchmark(c: &mut Criterion) {
     const NUM_CENTROIDS: usize = 256;
     const DIM: usize = 128;
 
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = rand::rng();
     let vecs: Vec<f32> = (0..NUM_VECTORS * DIM).map(|_| rng.random()).collect();
     let centroids: Vec<f32> = (0..NUM_CENTROIDS * DIM).map(|_| rng.random()).collect();
     let mut labels = vec![0; NUM_VECTORS];
@@ -81,5 +80,44 @@ fn assignment_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
+fn kmeans_benchmark(c: &mut Criterion) {
+    const NUM_VECTORS: usize = 50_176;
+    const NUM_CENTROIDS: usize = 256;
+    const DIM: usize = 128;
+    const ITERATIONS: usize = 5;
+
+    let mut rng = rand::rng();
+    let source: Vec<f32> = (0..NUM_VECTORS * DIM).map(|_| rng.random()).collect();
+    let vecs = gathers::utils::as_continuous_vec(&[source]);
+    let l2_kmeans = KMeans::new(
+        NUM_CENTROIDS as u32,
+        ITERATIONS as u32,
+        f32::MIN_POSITIVE,
+        Distance::SquaredEuclidean,
+        false,
+    );
+    let dot_kmeans = KMeans::new(
+        NUM_CENTROIDS as u32,
+        ITERATIONS as u32,
+        f32::MIN_POSITIVE,
+        Distance::NegativeDotProduct,
+        false,
+    );
+
+    let mut group = c.benchmark_group("kmeans");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements(
+        (NUM_VECTORS * NUM_CENTROIDS * ITERATIONS) as u64,
+    ));
+    group.bench_function("fit_50176x256x128_5iter", |b| {
+        b.iter(|| l2_kmeans.fit(black_box(vecs.clone()), DIM))
+    });
+    group.bench_function("fit_dot_50176x256x128_5iter", |b| {
+        b.iter(|| dot_kmeans.fit(black_box(vecs.clone()), DIM))
+    });
+    group.finish();
+}
+
 criterion_group!(assignment_benches, assignment_benchmark);
-criterion_main!(assignment_benches);
+criterion_group!(kmeans_benches, kmeans_benchmark);
+criterion_main!(kmeans_benches, assignment_benches);

--- a/benches/kmeans.rs
+++ b/benches/kmeans.rs
@@ -1,4 +1,4 @@
-use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use gathers::distance::Distance;
 use gathers::kmeans::{KMeans, base_assign, base_assign_parallel, rabitq_assign_parallel};
 use gathers::rabitq::RaBitQ;
@@ -110,10 +110,18 @@ fn kmeans_benchmark(c: &mut Criterion) {
         (NUM_VECTORS * NUM_CENTROIDS * ITERATIONS) as u64,
     ));
     group.bench_function("fit_50176x256x128_5iter", |b| {
-        b.iter(|| l2_kmeans.fit(black_box(vecs.clone()), DIM))
+        b.iter_batched(
+            || vecs.clone(),
+            |input| l2_kmeans.fit(black_box(input), DIM),
+            BatchSize::LargeInput,
+        )
     });
     group.bench_function("fit_dot_50176x256x128_5iter", |b| {
-        b.iter(|| dot_kmeans.fit(black_box(vecs.clone()), DIM))
+        b.iter_batched(
+            || vecs.clone(),
+            |input| dot_kmeans.fit(black_box(input), DIM),
+            BatchSize::LargeInput,
+        )
     });
     group.finish();
 }

--- a/benches/kmeans.rs
+++ b/benches/kmeans.rs
@@ -2,31 +2,18 @@ use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, cr
 use gathers::distance::Distance;
 use gathers::kmeans::{KMeans, base_assign, base_assign_parallel, rabitq_assign_parallel};
 use gathers::rabitq::RaBitQ;
-use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 use rayon::prelude::{
     IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator, ParallelSlice,
 };
-
-const BENCH_SEED_ENV: &str = "GATHERS_BENCH_SEED";
-
-fn benchmark_seed() -> u64 {
-    std::env::var(BENCH_SEED_ENV).map_or_else(
-        |_| rand::rng().random(),
-        |value| {
-            value
-                .parse()
-                .unwrap_or_else(|_| panic!("{BENCH_SEED_ENV} must be an unsigned 64-bit integer"))
-        },
-    )
-}
+use seed_rand::seeded_rng;
 
 fn assignment_benchmark(c: &mut Criterion) {
     const NUM_VECTORS: usize = 4096;
     const NUM_CENTROIDS: usize = 256;
     const DIM: usize = 128;
 
-    let mut rng = StdRng::seed_from_u64(benchmark_seed());
+    let mut rng = seeded_rng();
     let vecs: Vec<f32> = (0..NUM_VECTORS * DIM).map(|_| rng.random()).collect();
     let centroids: Vec<f32> = (0..NUM_CENTROIDS * DIM).map(|_| rng.random()).collect();
     let mut labels = vec![0; NUM_VECTORS];
@@ -100,8 +87,8 @@ fn kmeans_benchmark(c: &mut Criterion) {
     const DIM: usize = 128;
     const ITERATIONS: usize = 5;
 
-    let seed = benchmark_seed();
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = seeded_rng();
+    let seed = rng.random();
     let source: Vec<f32> = (0..NUM_VECTORS * DIM).map(|_| rng.random()).collect();
     let vecs = gathers::utils::as_continuous_vec(&[source]);
     let l2_kmeans = KMeans::new(

--- a/crates/seed_rand/Cargo.toml
+++ b/crates/seed_rand/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "seed-rand"
+version = "0.0.0"
+edition = "2024"
+rust-version = "1.85"
+publish = false
+
+[dependencies]
+rand = "0.9.3"

--- a/crates/seed_rand/src/lib.rs
+++ b/crates/seed_rand/src/lib.rs
@@ -1,0 +1,18 @@
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+const RANDOM_SEED_ENV: &str = "GATHERS_RANDOM_SEED";
+
+/// Creates a random generator from `GATHERS_RANDOM_SEED` or fresh entropy.
+pub fn seeded_rng() -> StdRng {
+    let seed = std::env::var(RANDOM_SEED_ENV).map_or_else(
+        |_| rand::rng().random(),
+        |value| {
+            value
+                .parse()
+                .unwrap_or_else(|_| panic!("{RANDOM_SEED_ENV} must be an unsigned 64-bit integer"))
+        },
+    );
+    eprintln!("random seed: {seed}; reproduce with {RANDOM_SEED_ENV}={seed}");
+    StdRng::seed_from_u64(seed)
+}

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -75,6 +75,26 @@ name = "bytemuck"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -108,6 +128,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "defer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
+
+[[package]]
 name = "dyn-stack"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +153,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "env_filter"
@@ -158,7 +202,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -169,7 +213,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -189,6 +233,7 @@ dependencies = [
  "nano-gemm",
  "num-complex",
  "num-traits",
+ "private-gemm-x86",
  "pulp",
  "reborrow",
 ]
@@ -201,7 +246,7 @@ checksum = "9d0a255d1442b5825c61812a7eafda9034ec53d969c98555251085e148428e6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -258,6 +303,7 @@ dependencies = [
  "gemm-c32",
  "gemm-c64",
  "gemm-common",
+ "gemm-f16",
  "gemm-f32",
  "gemm-f64",
  "num-complex",
@@ -305,12 +351,31 @@ checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
 dependencies = [
  "bytemuck",
  "dyn-stack",
+ "half",
  "libm",
  "num-complex",
  "num-traits",
  "once_cell",
  "paste",
  "pulp",
+ "raw-cpuid",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
  "raw-cpuid",
  "seq-macro",
 ]
@@ -364,16 +429,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "interpol"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb58032ba748f4010d15912a1855a8a0b1ba9eaad3395b0c171c09b3b356ae50"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "jiff"
@@ -398,7 +492,7 @@ checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -586,6 +680,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "numpy"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +739,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "private-gemm-x86"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af8c3e5087969c323f667ccb4b789fa0954f5aa650550e38e81cf9108be21b5"
+dependencies = [
+ "defer",
+ "interpol",
+ "num_cpus",
+ "raw-cpuid",
 ]
 
 [[package]]
@@ -707,7 +823,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -720,7 +836,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -872,6 +988,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "seq-macro"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,7 +1019,18 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -909,10 +1045,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -933,12 +1103,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -1040,5 +1229,5 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -134,12 +134,12 @@ pub fn argmin(vec: &[f32]) -> usize {
 #[cfg(test)]
 mod test {
     use rand::Rng;
+    use seed_rand::seeded_rng;
 
     use super::{
         argmin, l2_norm, l2_norm_native, native_argmin, native_dot_product,
         native_squared_euclidean, neg_dot_product, squared_euclidean,
     };
-    use seed_rand::seeded_rng;
 
     fn assert_f32_close(actual: f32, expected: f32, implementation: &str, dim: usize) {
         const ABS_TOLERANCE: f32 = 1e-6;

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -139,7 +139,7 @@ mod test {
         argmin, l2_norm, l2_norm_native, native_argmin, native_dot_product,
         native_squared_euclidean, neg_dot_product, squared_euclidean,
     };
-    use crate::test_utils::random_test_rng;
+    use seed_rand::seeded_rng;
 
     fn assert_f32_close(actual: f32, expected: f32, implementation: &str, dim: usize) {
         const ABS_TOLERANCE: f32 = 1e-6;
@@ -155,7 +155,7 @@ mod test {
 
     #[test]
     fn test_l2_squared_distance() {
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
         for _ in 0..100 {
             for dim in [4, 12, 64, 70, 78].into_iter() {
                 let lhs = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();
@@ -179,7 +179,7 @@ mod test {
 
     #[test]
     fn test_dot_product_distance() {
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
         for _ in 0..100 {
             for dim in [4, 12, 64, 70, 78].into_iter() {
                 let lhs = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();
@@ -206,7 +206,7 @@ mod test {
 
     #[test]
     fn test_l2_norm() {
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
         for _ in 0..100 {
             for dim in [4, 12, 64, 70, 78].into_iter() {
                 let vec = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();
@@ -228,7 +228,7 @@ mod test {
 
     #[test]
     fn test_argmin() {
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
         for _ in 0..100 {
             for dim in [12, 32, 128, 140].into_iter() {
                 let vec = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -133,19 +133,13 @@ pub fn argmin(vec: &[f32]) -> usize {
 
 #[cfg(test)]
 mod test {
-    use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::Rng;
 
     use super::{
         argmin, l2_norm, l2_norm_native, native_argmin, native_dot_product,
         native_squared_euclidean, neg_dot_product, squared_euclidean,
     };
-
-    fn random_test_rng() -> StdRng {
-        let seed = rand::rng().random();
-        eprintln!("random seed: {seed}");
-        StdRng::seed_from_u64(seed)
-    }
+    use crate::test_utils::random_test_rng;
 
     fn assert_f32_close(actual: f32, expected: f32, implementation: &str, dim: usize) {
         const ABS_TOLERANCE: f32 = 1e-6;

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -141,6 +141,12 @@ mod test {
         native_squared_euclidean, neg_dot_product, squared_euclidean,
     };
 
+    fn random_test_rng() -> StdRng {
+        let seed = rand::rng().random();
+        eprintln!("random seed: {seed}");
+        StdRng::seed_from_u64(seed)
+    }
+
     fn assert_f32_close(actual: f32, expected: f32, implementation: &str, dim: usize) {
         const ABS_TOLERANCE: f32 = 1e-6;
         const REL_TOLERANCE: f32 = 1e-5;
@@ -155,7 +161,7 @@ mod test {
 
     #[test]
     fn test_l2_squared_distance() {
-        let mut rng = rand::rng();
+        let mut rng = random_test_rng();
         for _ in 0..100 {
             for dim in [4, 12, 64, 70, 78].into_iter() {
                 let lhs = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();
@@ -179,7 +185,7 @@ mod test {
 
     #[test]
     fn test_dot_product_distance() {
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = random_test_rng();
         for _ in 0..100 {
             for dim in [4, 12, 64, 70, 78].into_iter() {
                 let lhs = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();
@@ -206,7 +212,7 @@ mod test {
 
     #[test]
     fn test_l2_norm() {
-        let mut rng = rand::rng();
+        let mut rng = random_test_rng();
         for _ in 0..100 {
             for dim in [4, 12, 64, 70, 78].into_iter() {
                 let vec = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();
@@ -228,7 +234,7 @@ mod test {
 
     #[test]
     fn test_argmin() {
-        let mut rng = rand::rng();
+        let mut rng = random_test_rng();
         for _ in 0..100 {
             for dim in [12, 32, 128, 140].into_iter() {
                 let vec = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -355,19 +355,23 @@ impl KMeans {
 
         let training_num = vecs.len() / dim;
         let mut labels: Vec<u32> = vec![0; training_num];
+        let use_exact_assignment = self.distance == Distance::NegativeDotProduct
+            || training_num * dim <= LARGE_CLUSTER_THRESHOLD;
         #[cfg(not(feature = "perf"))]
-        let mut matrix_workspace = matrix::MatrixAssignmentWorkspace::try_new(
-            &vecs,
-            centroids.len() / dim,
-            dim,
-            self.distance,
-        );
+        let mut matrix_workspace = if use_exact_assignment {
+            matrix::MatrixAssignmentWorkspace::try_new(
+                &vecs,
+                centroids.len() / dim,
+                dim,
+                self.distance,
+            )
+        } else {
+            None
+        };
         debug!("start training");
         for i in 0..self.max_iter {
             let start_time = Instant::now();
-            if self.distance == Distance::NegativeDotProduct
-                || training_num * dim <= LARGE_CLUSTER_THRESHOLD
-            {
+            if use_exact_assignment {
                 #[cfg(feature = "perf")]
                 base_assign(&vecs, &centroids, dim, self.distance, &mut labels);
                 #[cfg(not(feature = "perf"))]

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -441,8 +441,8 @@ mod test {
 
     use super::{KMeans, base_assign, base_assign_parallel, rabitq_assign, update_centroids};
     use crate::distance::{Distance, argmin, squared_euclidean};
-    use crate::test_utils::random_test_rng;
     use crate::utils::as_continuous_vec;
+    use seed_rand::seeded_rng;
 
     #[test]
     #[should_panic(expected = "dimension must be greater than zero")]
@@ -465,7 +465,7 @@ mod test {
 
     #[test]
     fn test_kmeans() {
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
         let dim = 32;
         let n = 1000;
         let km = KMeans::default();
@@ -518,7 +518,7 @@ mod test {
 
     #[test]
     fn test_parallel_assignment_matches_single_thread() {
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
         let dim = 32;
         let vecs = (0..257 * dim)
             .map(|_| rng.random::<f32>())

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -8,12 +8,13 @@ use std::time::Instant;
 
 use aligned_vec::AVec;
 use log::debug;
-use rand::Rng;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 use rayon::prelude::{IndexedParallelIterator, ParallelIterator, ParallelSlice, ParallelSliceMut};
 
 use crate::distance::{Distance, squared_euclidean};
 use crate::rabitq::{RaBitQ, RaBitQWorkspace};
-use crate::sampling::subsample;
+use crate::sampling::subsample_inner;
 use crate::utils::{as_continuous_vec, centroid_residual, normalize};
 
 const EPS: f32 = 1.0 / 1024.0;
@@ -172,6 +173,17 @@ pub fn rabitq_assign_parallel(vecs: &[f32], centroids: &[f32], dim: usize, label
 
 /// Update centroids to the mean of assigned vectors.
 pub fn update_centroids(vecs: &[f32], centroids: &mut [f32], dim: usize, labels: &[u32]) -> f32 {
+    let mut rng = rand::rng();
+    update_centroids_inner(vecs, centroids, dim, labels, &mut rng)
+}
+
+fn update_centroids_inner<R: Rng + ?Sized>(
+    vecs: &[f32],
+    centroids: &mut [f32],
+    dim: usize,
+    labels: &[u32],
+    rng: &mut R,
+) -> f32 {
     validate_assignment_inputs(vecs, centroids, dim, labels);
     let num_centroids = centroids.len() / dim;
     assert!(
@@ -207,7 +219,6 @@ pub fn update_centroids(vecs: &[f32], centroids: &mut [f32], dim: usize, labels:
         if cluster_sizes[empty_cluster] == 0 {
             // need to split another cluster to fill this empty cluster
             empty_cluster_count += 1;
-            let mut rng = rand::rng();
             let total_weight: usize = cluster_sizes
                 .iter()
                 .map(|&size| size.saturating_sub(1))
@@ -262,6 +273,7 @@ pub struct KMeans {
     distance: Distance,
     use_residual: bool,
     use_default_config: bool,
+    seed: Option<u64>,
 }
 
 impl Default for KMeans {
@@ -273,6 +285,7 @@ impl Default for KMeans {
             distance: Distance::default(),
             use_residual: false,
             use_default_config: true,
+            seed: None,
         }
     }
 }
@@ -310,11 +323,31 @@ impl KMeans {
             distance,
             use_residual,
             use_default_config: false,
+            seed: None,
         }
     }
 
+    /// Set the random seed used for sampling and empty-cluster repair.
+    pub fn seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     /// Fit the KMeans configurations to the given vectors and return the centroids.
-    pub fn fit(&self, mut vecs: AVec<f32>, dim: usize) -> AVec<f32> {
+    pub fn fit(&self, vecs: AVec<f32>, dim: usize) -> AVec<f32> {
+        if let Some(seed) = self.seed {
+            self.fit_inner(vecs, dim, &mut StdRng::seed_from_u64(seed))
+        } else {
+            self.fit_inner(vecs, dim, &mut rand::rng())
+        }
+    }
+
+    fn fit_inner<R: Rng + ?Sized>(
+        &self,
+        mut vecs: AVec<f32>,
+        dim: usize,
+        rng: &mut R,
+    ) -> AVec<f32> {
         validate_vectors(&vecs, dim);
         assert!(!vecs.is_empty(), "at least one vector is required");
 
@@ -345,10 +378,11 @@ impl KMeans {
         if num_vectors > MAX_POINTS_PER_CENTROID * num_clusters as usize {
             let n_sample = MAX_POINTS_PER_CENTROID * num_clusters as usize;
             debug!("subsample to {n_sample} points");
-            vecs = as_continuous_vec(&subsample(n_sample, &vecs, dim));
+            vecs = as_continuous_vec(&subsample_inner(n_sample, &vecs, dim, rng));
         }
 
-        let mut centroids = as_continuous_vec(&subsample(num_clusters as usize, &vecs, dim));
+        let mut centroids =
+            as_continuous_vec(&subsample_inner(num_clusters as usize, &vecs, dim, rng));
         if self.distance == Distance::NegativeDotProduct {
             centroids.chunks_mut(dim).for_each(normalize);
         }
@@ -386,7 +420,7 @@ impl KMeans {
                 #[cfg(not(feature = "perf"))]
                 rabitq_assign_parallel(&vecs, &centroids, dim, &mut labels);
             }
-            let diff = update_centroids(&vecs, &mut centroids, dim, &labels);
+            let diff = update_centroids_inner(&vecs, &mut centroids, dim, &labels, rng);
             if self.distance == Distance::NegativeDotProduct {
                 centroids.chunks_mut(dim).for_each(normalize);
             }

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -403,18 +403,12 @@ impl KMeans {
 
 #[cfg(test)]
 mod test {
-    use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::Rng;
 
     use super::{KMeans, base_assign, base_assign_parallel, rabitq_assign, update_centroids};
     use crate::distance::{Distance, argmin, squared_euclidean};
+    use crate::test_utils::random_test_rng;
     use crate::utils::as_continuous_vec;
-
-    fn random_test_rng() -> StdRng {
-        let seed = rand::rng().random();
-        eprintln!("random seed: {seed}");
-        StdRng::seed_from_u64(seed)
-    }
 
     #[test]
     #[should_panic(expected = "dimension must be greater than zero")]

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -1,5 +1,8 @@
 //! K-means clustering implementation.
 
+#[cfg(not(feature = "perf"))]
+mod matrix;
+
 use core::panic;
 use std::time::Instant;
 
@@ -352,6 +355,13 @@ impl KMeans {
 
         let training_num = vecs.len() / dim;
         let mut labels: Vec<u32> = vec![0; training_num];
+        #[cfg(not(feature = "perf"))]
+        let mut matrix_workspace = matrix::MatrixAssignmentWorkspace::try_new(
+            &vecs,
+            centroids.len() / dim,
+            dim,
+            self.distance,
+        );
         debug!("start training");
         for i in 0..self.max_iter {
             let start_time = Instant::now();
@@ -361,7 +371,11 @@ impl KMeans {
                 #[cfg(feature = "perf")]
                 base_assign(&vecs, &centroids, dim, self.distance, &mut labels);
                 #[cfg(not(feature = "perf"))]
-                base_assign_parallel(&vecs, &centroids, dim, self.distance, &mut labels);
+                if let Some(workspace) = &mut matrix_workspace {
+                    workspace.assign(&vecs, &centroids, dim, &mut labels);
+                } else {
+                    base_assign_parallel(&vecs, &centroids, dim, self.distance, &mut labels);
+                }
             } else {
                 #[cfg(feature = "perf")]
                 rabitq_assign(&vecs, &centroids, dim, &mut labels);
@@ -386,10 +400,18 @@ impl KMeans {
 #[cfg(test)]
 mod test {
     use rand::Rng;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     use super::{KMeans, base_assign, base_assign_parallel, rabitq_assign, update_centroids};
     use crate::distance::{Distance, argmin, squared_euclidean};
     use crate::utils::as_continuous_vec;
+
+    fn random_test_rng() -> StdRng {
+        let seed = rand::rng().random();
+        eprintln!("random seed: {seed}");
+        StdRng::seed_from_u64(seed)
+    }
 
     #[test]
     #[should_panic(expected = "dimension must be greater than zero")]
@@ -412,7 +434,7 @@ mod test {
 
     #[test]
     fn test_kmeans() {
-        let mut rng = rand::rng();
+        let mut rng = random_test_rng();
         let dim = 32;
         let n = 1000;
         let km = KMeans::default();
@@ -465,7 +487,7 @@ mod test {
 
     #[test]
     fn test_parallel_assignment_matches_single_thread() {
-        let mut rng = rand::rng();
+        let mut rng = random_test_rng();
         let dim = 32;
         let vecs = (0..257 * dim)
             .map(|_| rng.random::<f32>())

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -438,11 +438,11 @@ impl KMeans {
 #[cfg(test)]
 mod test {
     use rand::Rng;
+    use seed_rand::seeded_rng;
 
     use super::{KMeans, base_assign, base_assign_parallel, rabitq_assign, update_centroids};
     use crate::distance::{Distance, argmin, squared_euclidean};
     use crate::utils::as_continuous_vec;
-    use seed_rand::seeded_rng;
 
     #[test]
     #[should_panic(expected = "dimension must be greater than zero")]

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -399,9 +399,8 @@ impl KMeans {
 
 #[cfg(test)]
 mod test {
-    use rand::Rng;
-    use rand::SeedableRng;
     use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
 
     use super::{KMeans, base_assign, base_assign_parallel, rabitq_assign, update_centroids};
     use crate::distance::{Distance, argmin, squared_euclidean};

--- a/src/kmeans/matrix.rs
+++ b/src/kmeans/matrix.rs
@@ -15,11 +15,21 @@ const MATRIX_ASSIGNMENT_THRESHOLD: usize = 1 << 19;
 const SMALL_DIM_MATRIX_ASSIGNMENT_THRESHOLD: usize = 1 << 22;
 // Bound the reusable score matrix to 128 MiB.
 const MAX_MATRIX_ASSIGNMENT_ELEMENTS: usize = (128 << 20) / size_of::<f32>();
+// Higham's gamma_n error bound is finite only while n * epsilon is below one.
+const MAX_ERROR_BOUND_DIMENSION: usize = (1.0 / f32::EPSILON) as usize;
+const MATMUL_BLOCK_SIZE: usize = 256;
 // Additional engineering margins on top of using `f32::EPSILON`, which is already twice
 // Higham's unit roundoff. L2 needs more margin because it also adds two computed norms and can
 // suffer cancellation; dot-product scores only contain the reduction error.
 const L2_ERROR_BOUND_SAFETY_FACTOR: f32 = 8.0;
 const DOT_ERROR_BOUND_SAFETY_FACTOR: f32 = 1.0;
+
+fn try_zeroed(len: usize) -> Option<Vec<f32>> {
+    let mut values = Vec::new();
+    values.try_reserve_exact(len).ok()?;
+    values.resize(len, 0.0);
+    Some(values)
+}
 
 pub(super) struct MatrixAssignmentWorkspace {
     distance: Distance,
@@ -42,22 +52,26 @@ impl MatrixAssignmentWorkspace {
         } else {
             MATRIX_ASSIGNMENT_THRESHOLD
         };
-        if dim < 32
+        if !(32..MAX_ERROR_BOUND_DIMENSION).contains(&dim)
             || num_centroids < 2
+            || MATMUL_BLOCK_SIZE.checked_mul(num_centroids).is_none()
             || !(assignment_threshold..=MAX_MATRIX_ASSIGNMENT_ELEMENTS).contains(&comparison_count)
         {
             return None;
         }
 
-        let vector_norms = vecs
-            .par_chunks_exact(dim)
-            .map(|vector| vector.iter().map(|value| value * value).sum())
-            .collect();
+        let mut vector_norms = try_zeroed(num_vectors)?;
+        vector_norms
+            .par_iter_mut()
+            .zip(vecs.par_chunks_exact(dim))
+            .for_each(|(norm, vector)| {
+                *norm = vector.iter().map(|value| value * value).sum();
+            });
         Some(Self {
             distance,
             vector_norms,
-            centroid_norms: vec![0.0; num_centroids],
-            dot_products: vec![0.0; comparison_count],
+            centroid_norms: try_zeroed(num_centroids)?,
+            dot_products: try_zeroed(comparison_count)?,
         })
     }
 
@@ -75,7 +89,6 @@ impl MatrixAssignmentWorkspace {
 
         // Process 256 input rows per GEMM task; tuned on Apple Silicon with
         // benchmark datasets averaging 196 training vectors per centroid.
-        const MATMUL_BLOCK_SIZE: usize = 256;
         let scale = match self.distance {
             Distance::SquaredEuclidean => -2.0,
             Distance::NegativeDotProduct => -1.0,
@@ -105,6 +118,7 @@ impl MatrixAssignmentWorkspace {
             .for_each(|(norm, centroid)| {
                 *norm = centroid.iter().map(|value| value * value).sum();
             });
+        let centroid_norms_are_finite = self.centroid_norms.iter().all(|norm| norm.is_finite());
         let max_centroid_norm = self.centroid_norms.iter().copied().fold(0.0_f32, f32::max);
         // Higham, Accuracy and Stability of Numerical Algorithms, Chapters 2-3,
         // bounds an n-term floating-point reduction with gamma_n = n*u/(1-n*u):
@@ -142,16 +156,21 @@ impl MatrixAssignmentWorkspace {
                         * vector_norm.sqrt()
                         * max_centroid_norm;
                     let ambiguity = 2.0 * uncertainty;
-                    if !best_score.is_finite() || second_best_score - best_score <= ambiguity {
-                        let mut exact_label = [0];
+                    if !centroid_norms_are_finite
+                        || !vector_norm.is_finite()
+                        || !uncertainty.is_finite()
+                        || !best_score.is_finite()
+                        || second_best_score - best_score <= ambiguity
+                    {
+                        let mut direct = [0];
                         base_assign(
                             vector,
                             centroids,
                             dim,
                             Distance::NegativeDotProduct,
-                            &mut exact_label,
+                            &mut direct,
                         );
-                        *label = exact_label[0];
+                        *label = direct[0];
                     } else {
                         *label = best_index as u32;
                     }
@@ -188,16 +207,20 @@ impl MatrixAssignmentWorkspace {
                     * (vector_norm.abs() + max_centroid_norm.abs());
                 // Two estimates can each err in opposite directions by `uncertainty`.
                 let ambiguity = 2.0 * uncertainty;
-                if !best_distance.is_finite() {
-                    let mut exact_label = [0];
+                if !centroid_norms_are_finite
+                    || !vector_norm.is_finite()
+                    || !uncertainty.is_finite()
+                    || !best_distance.is_finite()
+                {
+                    let mut direct = [0];
                     base_assign(
                         vector,
                         centroids,
                         dim,
                         Distance::SquaredEuclidean,
-                        &mut exact_label,
+                        &mut direct,
                     );
-                    *label = exact_label[0];
+                    *label = direct[0];
                 } else if best_distance < 0.0 || second_best_distance - best_distance <= ambiguity {
                     let cutoff = best_distance + ambiguity;
                     let mut exact_best_distance = f32::MAX;
@@ -233,13 +256,8 @@ mod tests {
     use super::MatrixAssignmentWorkspace;
     use crate::distance::Distance;
     use crate::kmeans::base_assign;
+    use crate::test_utils::random_test_rng;
     use crate::utils::normalize;
-
-    fn random_test_rng() -> StdRng {
-        let seed = rand::rng().random();
-        eprintln!("random seed: {seed}");
-        StdRng::seed_from_u64(seed)
-    }
 
     #[test]
     fn test_matrix_assignment_matches_direct_assignment() {
@@ -372,6 +390,35 @@ mod tests {
             let centroid = &centroids[(index % num_centroids) * dim..][..dim];
             vecs.extend_from_slice(centroid);
             *vecs.last_mut().unwrap() += 0.125;
+        }
+        let mut labels = vec![0; num_vectors];
+
+        let mut workspace = MatrixAssignmentWorkspace::try_new(
+            &vecs,
+            num_centroids,
+            dim,
+            Distance::SquaredEuclidean,
+        )
+        .unwrap();
+        workspace.assign(&vecs, &centroids, dim, &mut labels);
+
+        for (index, &label) in labels.iter().enumerate() {
+            assert_eq!(label as usize, index % num_centroids);
+        }
+    }
+
+    #[test]
+    fn test_matrix_assignment_handles_overflowed_norms() {
+        let dim = 64;
+        let num_vectors = 8192;
+        let num_centroids = 64;
+        let mut centroids = vec![1e20; num_centroids * dim];
+        for (index, centroid) in centroids.chunks_exact_mut(dim).enumerate() {
+            centroid[0] += index as f32 * 1e14;
+        }
+        let mut vecs = Vec::with_capacity(num_vectors * dim);
+        for index in 0..num_vectors {
+            vecs.extend_from_slice(&centroids[(index % num_centroids) * dim..][..dim]);
         }
         let mut labels = vec![0; num_vectors];
 

--- a/src/kmeans/matrix.rs
+++ b/src/kmeans/matrix.rs
@@ -73,10 +73,40 @@ fn best_two(scores: impl Iterator<Item = f32>) -> (f32, f32, usize) {
 }
 
 impl Distance {
+    fn matrix_scale(self) -> f32 {
+        match self {
+            Self::SquaredEuclidean => -2.0,
+            Self::NegativeDotProduct => -1.0,
+        }
+    }
+
     fn matrix_norm(self, values: &[f32]) -> f32 {
         match self {
             Self::SquaredEuclidean => values.iter().map(|value| value * value).sum(),
             Self::NegativeDotProduct => stable_l2_norm(values),
+        }
+    }
+
+    fn matrix_uncertainty(
+        self,
+        gamma: f32,
+        vector_norm: f32,
+        max_centroid_norm: f32,
+        underflow_error: f32,
+    ) -> f32 {
+        match self {
+            // The norm identity can suffer cancellation. The safety factor is an
+            // engineering margin, not part of Higham's gamma_n bound.
+            Self::SquaredEuclidean => {
+                L2_ERROR_BOUND_SAFETY_FACTOR
+                    * (gamma * (vector_norm.abs() + max_centroid_norm.abs()) + underflow_error)
+            }
+            // Cauchy-Schwarz bounds the magnitude of the exact dot product by
+            // ||x||₂ ||c||₂.
+            Self::NegativeDotProduct => {
+                DOT_ERROR_BOUND_SAFETY_FACTOR
+                    * (gamma * vector_norm * max_centroid_norm + underflow_error)
+            }
         }
     }
 }
@@ -139,10 +169,7 @@ impl MatrixAssignmentWorkspace {
 
         // Process 256 input rows per GEMM task; tuned on Apple Silicon with
         // benchmark datasets averaging 196 training vectors per centroid.
-        let scale = match self.distance {
-            Distance::SquaredEuclidean => -2.0,
-            Distance::NegativeDotProduct => -1.0,
-        };
+        let scale = self.distance.matrix_scale();
         self.dot_products
             .par_chunks_mut(MATMUL_BLOCK_SIZE * num_centroids)
             .zip(vecs.par_chunks(MATMUL_BLOCK_SIZE * dim))
@@ -197,21 +224,12 @@ impl MatrixAssignmentWorkspace {
                     ),
                 };
 
-                let uncertainty = match distance {
-                    // Cauchy-Schwarz bounds the magnitude of the exact dot product by
-                    // ||x||₂ ||c||₂.
-                    Distance::NegativeDotProduct => {
-                        DOT_ERROR_BOUND_SAFETY_FACTOR
-                            * (gamma * vector_norm * max_centroid_norm + underflow_error)
-                    }
-                    // The norm identity can suffer cancellation. The safety factor is an
-                    // engineering margin, not part of Higham's gamma_n bound.
-                    Distance::SquaredEuclidean => {
-                        L2_ERROR_BOUND_SAFETY_FACTOR
-                            * (gamma * (vector_norm.abs() + max_centroid_norm.abs())
-                                + underflow_error)
-                    }
-                };
+                let uncertainty = distance.matrix_uncertainty(
+                    gamma,
+                    vector_norm,
+                    max_centroid_norm,
+                    underflow_error,
+                );
                 // Two estimates can each err in opposite directions by `uncertainty`.
                 let ambiguity = 2.0 * uncertainty;
                 let invalid = !centroid_norms_are_finite

--- a/src/kmeans/matrix.rs
+++ b/src/kmeans/matrix.rs
@@ -1,0 +1,319 @@
+use faer::linalg::matmul::matmul;
+use faer::{Accum, MatMut, MatRef, Par};
+use rayon::prelude::{
+    IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator, ParallelSlice,
+    ParallelSliceMut,
+};
+
+use super::base_assign;
+use crate::distance::{Distance, squared_euclidean};
+
+// These crossover and block-size choices are tuned on Apple Silicon. Other targets use the
+// same safe defaults until platform-specific benchmarks justify changing them.
+const MATRIX_ASSIGNMENT_THRESHOLD: usize = 1 << 19;
+// Matrix setup is proportionally more expensive at dimensions below 64.
+const SMALL_DIM_MATRIX_ASSIGNMENT_THRESHOLD: usize = 1 << 22;
+// Bound the reusable score matrix to 128 MiB.
+const MAX_MATRIX_ASSIGNMENT_ELEMENTS: usize = (128 << 20) / size_of::<f32>();
+// Additional engineering margin for the norm, dot-product, and final addition errors.
+const L2_ERROR_BOUND_SAFETY_FACTOR: f32 = 8.0;
+
+pub(super) struct MatrixAssignmentWorkspace {
+    distance: Distance,
+    vector_norms: Vec<f32>,
+    centroid_norms: Vec<f32>,
+    dot_products: Vec<f32>,
+}
+
+impl MatrixAssignmentWorkspace {
+    pub(super) fn try_new(
+        vecs: &[f32],
+        num_centroids: usize,
+        dim: usize,
+        distance: Distance,
+    ) -> Option<Self> {
+        let num_vectors = vecs.len() / dim;
+        let comparison_count = num_vectors.checked_mul(num_centroids)?;
+        let assignment_threshold = if dim < 64 {
+            SMALL_DIM_MATRIX_ASSIGNMENT_THRESHOLD
+        } else {
+            MATRIX_ASSIGNMENT_THRESHOLD
+        };
+        if dim < 32
+            || num_centroids < 2
+            || !(assignment_threshold..=MAX_MATRIX_ASSIGNMENT_ELEMENTS).contains(&comparison_count)
+        {
+            return None;
+        }
+
+        let vector_norms = if distance == Distance::SquaredEuclidean {
+            vecs.par_chunks_exact(dim)
+                .map(|vector| vector.iter().map(|value| value * value).sum())
+                .collect()
+        } else {
+            Vec::new()
+        };
+        Some(Self {
+            distance,
+            vector_norms,
+            centroid_norms: if distance == Distance::SquaredEuclidean {
+                vec![0.0; num_centroids]
+            } else {
+                Vec::new()
+            },
+            dot_products: vec![0.0; comparison_count],
+        })
+    }
+
+    pub(super) fn assign(
+        &mut self,
+        vecs: &[f32],
+        centroids: &[f32],
+        dim: usize,
+        labels: &mut [u32],
+    ) {
+        let num_centroids = centroids.len() / dim;
+        if self.distance == Distance::SquaredEuclidean {
+            debug_assert_eq!(self.vector_norms.len(), vecs.len() / dim);
+            debug_assert_eq!(self.centroid_norms.len(), num_centroids);
+        }
+        debug_assert_eq!(self.dot_products.len(), labels.len() * num_centroids);
+
+        // Process 256 input rows per GEMM task; tuned on Apple Silicon with
+        // benchmark datasets averaging 196 training vectors per centroid.
+        const MATMUL_BLOCK_SIZE: usize = 256;
+        let scale = match self.distance {
+            Distance::SquaredEuclidean => -2.0,
+            Distance::NegativeDotProduct => -1.0,
+        };
+        self.dot_products
+            .par_chunks_mut(MATMUL_BLOCK_SIZE * num_centroids)
+            .zip(vecs.par_chunks(MATMUL_BLOCK_SIZE * dim))
+            .for_each(|(dot_products, vectors)| {
+                let block_rows = vectors.len() / dim;
+                let vectors = MatRef::from_row_major_slice(vectors, block_rows, dim);
+                let centroids = MatRef::from_row_major_slice(centroids, num_centroids, dim);
+                let scores =
+                    MatMut::from_row_major_slice_mut(dot_products, block_rows, num_centroids);
+                matmul(
+                    scores,
+                    Accum::Replace,
+                    vectors,
+                    centroids.transpose(),
+                    scale,
+                    Par::Seq,
+                );
+            });
+
+        if self.distance == Distance::NegativeDotProduct {
+            labels
+                .par_iter_mut()
+                .zip(self.dot_products.par_chunks_exact(num_centroids))
+                .for_each(|(label, scores)| {
+                    let mut best_score = f32::MAX;
+                    let mut best_index = 0;
+                    for (index, &score) in scores.iter().enumerate() {
+                        if score < best_score {
+                            best_score = score;
+                            best_index = index;
+                        }
+                    }
+                    *label = best_index as u32;
+                });
+            return;
+        }
+
+        self.centroid_norms
+            .par_iter_mut()
+            .zip(centroids.par_chunks_exact(dim))
+            .for_each(|(norm, centroid)| {
+                *norm = centroid.iter().map(|value| value * value).sum();
+            });
+        let max_centroid_norm = self.centroid_norms.iter().copied().fold(0.0_f32, f32::max);
+        // Higham, Accuracy and Stability of Numerical Algorithms, Chapters 2-3,
+        // bounds an n-term floating-point reduction with gamma_n = n*u/(1-n*u):
+        // https://doi.org/10.1137/1.9780898718027. `f32::EPSILON` is about 2*u,
+        // so using it here is already conservative.
+        let dimension_error = dim as f32 * f32::EPSILON;
+        let gamma = dimension_error / (1.0 - dimension_error);
+
+        labels
+            .par_iter_mut()
+            .zip(&self.vector_norms)
+            .zip(vecs.par_chunks_exact(dim))
+            .zip(self.dot_products.par_chunks_exact(num_centroids))
+            .for_each(|(((label, &vector_norm), vector), scores)| {
+                let mut best_distance = f32::MAX;
+                let mut second_best_distance = f32::MAX;
+                let mut best_index = 0;
+                for (index, (&score, &centroid_norm)) in
+                    scores.iter().zip(&self.centroid_norms).enumerate()
+                {
+                    let distance = score + vector_norm + centroid_norm;
+                    if distance < best_distance {
+                        second_best_distance = best_distance;
+                        best_distance = distance;
+                        best_index = index;
+                    } else if distance < second_best_distance {
+                        second_best_distance = distance;
+                    }
+                }
+
+                // The norm identity can suffer cancellation. The safety factor is an
+                // engineering margin, not part of Higham's gamma_n bound.
+                let uncertainty = L2_ERROR_BOUND_SAFETY_FACTOR
+                    * gamma
+                    * (vector_norm.abs() + max_centroid_norm.abs());
+                // Two estimates can each err in opposite directions by `uncertainty`.
+                let ambiguity = 2.0 * uncertainty;
+                if !best_distance.is_finite() {
+                    let mut exact_label = [0];
+                    base_assign(
+                        vector,
+                        centroids,
+                        dim,
+                        Distance::SquaredEuclidean,
+                        &mut exact_label,
+                    );
+                    *label = exact_label[0];
+                } else if best_distance < 0.0 || second_best_distance - best_distance <= ambiguity {
+                    let cutoff = best_distance + ambiguity;
+                    let mut exact_best_distance = f32::MAX;
+                    let mut exact_best_index = best_index;
+                    for (index, ((&score, &centroid_norm), centroid)) in scores
+                        .iter()
+                        .zip(&self.centroid_norms)
+                        .zip(centroids.chunks_exact(dim))
+                        .enumerate()
+                    {
+                        let approximate_distance = score + vector_norm + centroid_norm;
+                        if approximate_distance <= cutoff {
+                            let exact_distance = squared_euclidean(vector, centroid);
+                            if exact_distance < exact_best_distance {
+                                exact_best_distance = exact_distance;
+                                exact_best_index = index;
+                            }
+                        }
+                    }
+                    *label = exact_best_index as u32;
+                } else {
+                    *label = best_index as u32;
+                }
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    use super::MatrixAssignmentWorkspace;
+    use crate::distance::Distance;
+    use crate::kmeans::base_assign;
+
+    fn random_test_rng() -> StdRng {
+        let seed = rand::rng().random();
+        eprintln!("random seed: {seed}");
+        StdRng::seed_from_u64(seed)
+    }
+
+    #[test]
+    fn test_matrix_assignment_matches_direct_assignment() {
+        let mut rng = random_test_rng();
+        let dim = 64;
+        let num_vectors = 8192;
+        let num_centroids = 64;
+        let vecs = (0..num_vectors * dim)
+            .map(|_| rng.random::<f32>())
+            .collect::<Vec<_>>();
+        let centroids = (0..num_centroids * dim)
+            .map(|_| rng.random::<f32>())
+            .collect::<Vec<_>>();
+        let mut expected = vec![0; num_vectors];
+        let mut actual = vec![0; num_vectors];
+
+        base_assign(
+            &vecs,
+            &centroids,
+            dim,
+            Distance::SquaredEuclidean,
+            &mut expected,
+        );
+        let mut workspace = MatrixAssignmentWorkspace::try_new(
+            &vecs,
+            num_centroids,
+            dim,
+            Distance::SquaredEuclidean,
+        )
+        .unwrap();
+        workspace.assign(&vecs, &centroids, dim, &mut actual);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_matrix_dot_product_matches_direct_assignment() {
+        let mut rng = random_test_rng();
+        let dim = 64;
+        let num_vectors = 8192;
+        let num_centroids = 64;
+        let vecs = (0..num_vectors * dim)
+            .map(|_| rng.random::<f32>())
+            .collect::<Vec<_>>();
+        let centroids = (0..num_centroids * dim)
+            .map(|_| rng.random::<f32>())
+            .collect::<Vec<_>>();
+        let mut expected = vec![0; num_vectors];
+        let mut actual = vec![0; num_vectors];
+
+        base_assign(
+            &vecs,
+            &centroids,
+            dim,
+            Distance::NegativeDotProduct,
+            &mut expected,
+        );
+        let mut workspace = MatrixAssignmentWorkspace::try_new(
+            &vecs,
+            num_centroids,
+            dim,
+            Distance::NegativeDotProduct,
+        )
+        .unwrap();
+        workspace.assign(&vecs, &centroids, dim, &mut actual);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_matrix_assignment_handles_large_common_offset() {
+        let dim = 64;
+        let num_vectors = 8192;
+        let num_centroids = 64;
+        let mut centroids = vec![1_000_000.0; num_centroids * dim];
+        for (index, centroid) in centroids.chunks_exact_mut(dim).enumerate() {
+            centroid[0] += index as f32 * 2.0;
+        }
+        let mut vecs = Vec::with_capacity(num_vectors * dim);
+        for index in 0..num_vectors {
+            let centroid = &centroids[(index % num_centroids) * dim..][..dim];
+            vecs.extend_from_slice(centroid);
+            *vecs.last_mut().unwrap() += 0.125;
+        }
+        let mut labels = vec![0; num_vectors];
+
+        let mut workspace = MatrixAssignmentWorkspace::try_new(
+            &vecs,
+            num_centroids,
+            dim,
+            Distance::SquaredEuclidean,
+        )
+        .unwrap();
+        workspace.assign(&vecs, &centroids, dim, &mut labels);
+
+        for (index, &label) in labels.iter().enumerate() {
+            assert_eq!(label as usize, index % num_centroids);
+        }
+    }
+}

--- a/src/kmeans/matrix.rs
+++ b/src/kmeans/matrix.rs
@@ -56,6 +56,22 @@ fn stable_l2_norm(values: &[f32]) -> f32 {
     scale * scaled_sum.sqrt()
 }
 
+fn best_two(scores: impl Iterator<Item = f32>) -> (f32, f32, usize) {
+    let mut best = f32::MAX;
+    let mut second_best = f32::MAX;
+    let mut best_index = 0;
+    for (index, score) in scores.enumerate() {
+        if score < best {
+            second_best = best;
+            best = score;
+            best_index = index;
+        } else if score < second_best {
+            second_best = score;
+        }
+    }
+    (best, second_best, best_index)
+}
+
 impl Distance {
     fn matrix_norm(self, values: &[f32]) -> f32 {
         match self {
@@ -164,98 +180,55 @@ impl MatrixAssignmentWorkspace {
         // unit per reduction term so tiny, finite inputs still trigger the ambiguity fallback.
         let underflow_error = dim as f32 * MIN_SUBNORMAL;
 
-        if self.distance == Distance::NegativeDotProduct {
-            labels
-                .par_iter_mut()
-                .zip(&self.vector_norms)
-                .zip(vecs.par_chunks_exact(dim))
-                .zip(self.dot_products.par_chunks_exact(num_centroids))
-                .for_each(|(((label, &vector_norm), vector), scores)| {
-                    let mut best_score = f32::MAX;
-                    let mut second_best_score = f32::MAX;
-                    let mut best_index = 0;
-                    for (index, &score) in scores.iter().enumerate() {
-                        if score < best_score {
-                            second_best_score = best_score;
-                            best_score = score;
-                            best_index = index;
-                        } else if score < second_best_score {
-                            second_best_score = score;
-                        }
-                    }
-
-                    // Cauchy-Schwarz bounds the magnitude of the exact dot product by
-                    // ||x||₂ ||c||₂. Scores whose error intervals overlap are recomputed
-                    // with the direct implementation to preserve its assignment semantics.
-                    let uncertainty = DOT_ERROR_BOUND_SAFETY_FACTOR
-                        * (gamma * vector_norm * max_centroid_norm + underflow_error);
-                    let ambiguity = 2.0 * uncertainty;
-                    if !centroid_norms_are_finite
-                        || !vector_norm.is_finite()
-                        || !uncertainty.is_finite()
-                        || !best_score.is_finite()
-                        || second_best_score - best_score <= ambiguity
-                    {
-                        let mut direct = [0];
-                        base_assign(
-                            vector,
-                            centroids,
-                            dim,
-                            Distance::NegativeDotProduct,
-                            &mut direct,
-                        );
-                        *label = direct[0];
-                    } else {
-                        *label = best_index as u32;
-                    }
-                });
-            return;
-        }
-
+        let distance = self.distance;
         labels
             .par_iter_mut()
             .zip(&self.vector_norms)
             .zip(vecs.par_chunks_exact(dim))
             .zip(self.dot_products.par_chunks_exact(num_centroids))
             .for_each(|(((label, &vector_norm), vector), scores)| {
-                let mut best_distance = f32::MAX;
-                let mut second_best_distance = f32::MAX;
-                let mut best_index = 0;
-                for (index, (&score, &centroid_norm)) in
-                    scores.iter().zip(&self.centroid_norms).enumerate()
-                {
-                    let distance = score + vector_norm + centroid_norm;
-                    if distance < best_distance {
-                        second_best_distance = best_distance;
-                        best_distance = distance;
-                        best_index = index;
-                    } else if distance < second_best_distance {
-                        second_best_distance = distance;
-                    }
-                }
+                let (best_score, second_best_score, best_index) = match distance {
+                    Distance::NegativeDotProduct => best_two(scores.iter().copied()),
+                    Distance::SquaredEuclidean => best_two(
+                        scores
+                            .iter()
+                            .zip(&self.centroid_norms)
+                            .map(|(&score, &centroid_norm)| score + vector_norm + centroid_norm),
+                    ),
+                };
 
-                // The norm identity can suffer cancellation. The safety factor is an
-                // engineering margin, not part of Higham's gamma_n bound.
-                let uncertainty = L2_ERROR_BOUND_SAFETY_FACTOR
-                    * (gamma * (vector_norm.abs() + max_centroid_norm.abs()) + underflow_error);
+                let uncertainty = match distance {
+                    // Cauchy-Schwarz bounds the magnitude of the exact dot product by
+                    // ||x||₂ ||c||₂.
+                    Distance::NegativeDotProduct => {
+                        DOT_ERROR_BOUND_SAFETY_FACTOR
+                            * (gamma * vector_norm * max_centroid_norm + underflow_error)
+                    }
+                    // The norm identity can suffer cancellation. The safety factor is an
+                    // engineering margin, not part of Higham's gamma_n bound.
+                    Distance::SquaredEuclidean => {
+                        L2_ERROR_BOUND_SAFETY_FACTOR
+                            * (gamma * (vector_norm.abs() + max_centroid_norm.abs())
+                                + underflow_error)
+                    }
+                };
                 // Two estimates can each err in opposite directions by `uncertainty`.
                 let ambiguity = 2.0 * uncertainty;
-                if !centroid_norms_are_finite
+                let invalid = !centroid_norms_are_finite
                     || !vector_norm.is_finite()
                     || !uncertainty.is_finite()
-                    || !best_distance.is_finite()
-                {
+                    || !best_score.is_finite();
+                let use_direct = invalid
+                    || (distance == Distance::NegativeDotProduct
+                        && second_best_score - best_score <= ambiguity);
+                if use_direct {
                     let mut direct = [0];
-                    base_assign(
-                        vector,
-                        centroids,
-                        dim,
-                        Distance::SquaredEuclidean,
-                        &mut direct,
-                    );
+                    base_assign(vector, centroids, dim, distance, &mut direct);
                     *label = direct[0];
-                } else if best_distance < 0.0 || second_best_distance - best_distance <= ambiguity {
-                    let cutoff = best_distance + ambiguity;
+                } else if distance == Distance::SquaredEuclidean
+                    && (best_score < 0.0 || second_best_score - best_score <= ambiguity)
+                {
+                    let cutoff = best_score + ambiguity;
                     let mut exact_best_distance = f32::MAX;
                     let mut exact_best_index = best_index;
                     for (index, ((&score, &centroid_norm), centroid)) in scores

--- a/src/kmeans/matrix.rs
+++ b/src/kmeans/matrix.rs
@@ -285,12 +285,12 @@ impl MatrixAssignmentWorkspace {
 mod tests {
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
+    use seed_rand::seeded_rng;
 
     use super::MatrixAssignmentWorkspace;
     use crate::distance::Distance;
     use crate::kmeans::base_assign;
     use crate::utils::normalize;
-    use seed_rand::seeded_rng;
 
     #[test]
     fn test_matrix_assignment_matches_direct_assignment() {

--- a/src/kmeans/matrix.rs
+++ b/src/kmeans/matrix.rs
@@ -32,6 +32,39 @@ fn try_zeroed(len: usize) -> Option<Vec<f32>> {
     Some(values)
 }
 
+fn stable_l2_norm(values: &[f32]) -> f32 {
+    let mut scale = 0.0_f32;
+    for &value in values {
+        if !value.is_finite() {
+            // Preserve NaN or infinity so assignment detects a non-finite bound and falls back to
+            // the direct implementation.
+            return value.abs();
+        }
+        scale = scale.max(value.abs());
+    }
+    if scale == 0.0 {
+        return 0.0;
+    }
+
+    let scaled_sum = values
+        .iter()
+        .map(|&value| {
+            let scaled = value / scale;
+            scaled * scaled
+        })
+        .sum::<f32>();
+    scale * scaled_sum.sqrt()
+}
+
+impl Distance {
+    fn matrix_norm(self, values: &[f32]) -> f32 {
+        match self {
+            Self::SquaredEuclidean => values.iter().map(|value| value * value).sum(),
+            Self::NegativeDotProduct => stable_l2_norm(values),
+        }
+    }
+}
+
 pub(super) struct MatrixAssignmentWorkspace {
     distance: Distance,
     vector_norms: Vec<f32>,
@@ -66,7 +99,7 @@ impl MatrixAssignmentWorkspace {
             .par_iter_mut()
             .zip(vecs.par_chunks_exact(dim))
             .for_each(|(norm, vector)| {
-                *norm = vector.iter().map(|value| value * value).sum();
+                *norm = distance.matrix_norm(vector);
             });
         Some(Self {
             distance,
@@ -117,7 +150,7 @@ impl MatrixAssignmentWorkspace {
             .par_iter_mut()
             .zip(centroids.par_chunks_exact(dim))
             .for_each(|(norm, centroid)| {
-                *norm = centroid.iter().map(|value| value * value).sum();
+                *norm = self.distance.matrix_norm(centroid);
             });
         let centroid_norms_are_finite = self.centroid_norms.iter().all(|norm| norm.is_finite());
         let max_centroid_norm = self.centroid_norms.iter().copied().fold(0.0_f32, f32::max);
@@ -132,7 +165,6 @@ impl MatrixAssignmentWorkspace {
         let underflow_error = dim as f32 * MIN_SUBNORMAL;
 
         if self.distance == Distance::NegativeDotProduct {
-            let max_centroid_norm = max_centroid_norm.sqrt();
             labels
                 .par_iter_mut()
                 .zip(&self.vector_norms)
@@ -156,7 +188,7 @@ impl MatrixAssignmentWorkspace {
                     // ||x||₂ ||c||₂. Scores whose error intervals overlap are recomputed
                     // with the direct implementation to preserve its assignment semantics.
                     let uncertainty = DOT_ERROR_BOUND_SAFETY_FACTOR
-                        * (gamma * vector_norm.sqrt() * max_centroid_norm + underflow_error);
+                        * (gamma * vector_norm * max_centroid_norm + underflow_error);
                     let ambiguity = 2.0 * uncertainty;
                     if !centroid_norms_are_finite
                         || !vector_norm.is_finite()
@@ -484,6 +516,57 @@ mod tests {
         let mut vecs = Vec::with_capacity(num_vectors * dim);
         for index in 0..num_vectors {
             vecs.extend_from_slice(&centroids[(index % num_centroids) * dim..][..dim]);
+        }
+        let mut expected = vec![0; num_vectors];
+        let mut actual = vec![0; num_vectors];
+
+        base_assign(
+            &vecs,
+            &centroids,
+            dim,
+            Distance::NegativeDotProduct,
+            &mut expected,
+        );
+        let mut workspace = MatrixAssignmentWorkspace::try_new(
+            &vecs,
+            num_centroids,
+            dim,
+            Distance::NegativeDotProduct,
+        )
+        .unwrap();
+        workspace.assign(&vecs, &centroids, dim, &mut actual);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_matrix_dot_product_handles_asymmetric_scales() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let dim = 64;
+        let num_vectors = 8192;
+        let num_centroids = 64;
+        let mut direction = (0..dim)
+            .map(|_| rng.random::<f32>() * 2.0 - 1.0)
+            .collect::<Vec<_>>();
+        normalize(&mut direction);
+        let mut centroids = Vec::with_capacity(num_centroids * dim);
+        for _ in 0..num_centroids {
+            let mut centroid = direction.clone();
+            centroid.iter_mut().for_each(|value| {
+                *value += (rng.random::<f32>() * 2.0 - 1.0) * 1e-6;
+            });
+            normalize(&mut centroid);
+            centroid.iter_mut().for_each(|value| *value *= 1e15);
+            centroids.extend(centroid);
+        }
+        let mut vecs = Vec::with_capacity(num_vectors * dim);
+        for _ in 0..num_vectors {
+            let mut vector = (0..dim)
+                .map(|_| rng.random::<f32>() * 2.0 - 1.0)
+                .collect::<Vec<_>>();
+            normalize(&mut vector);
+            vector.iter_mut().for_each(|value| *value *= 1e-25);
+            vecs.extend(vector);
         }
         let mut expected = vec![0; num_vectors];
         let mut actual = vec![0; num_vectors];

--- a/src/kmeans/matrix.rs
+++ b/src/kmeans/matrix.rs
@@ -289,12 +289,12 @@ mod tests {
     use super::MatrixAssignmentWorkspace;
     use crate::distance::Distance;
     use crate::kmeans::base_assign;
-    use crate::test_utils::random_test_rng;
     use crate::utils::normalize;
+    use seed_rand::seeded_rng;
 
     #[test]
     fn test_matrix_assignment_matches_direct_assignment() {
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
         let dim = 64;
         let num_vectors = 8192;
         let num_centroids = 64;
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn test_matrix_dot_product_matches_direct_assignment() {
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
         let dim = 64;
         let num_vectors = 8192;
         let num_centroids = 64;
@@ -362,7 +362,7 @@ mod tests {
 
     #[test]
     fn test_matrix_assignment_reuses_workspace_with_updated_centroids() {
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
         let dim = 64;
         let num_vectors = 8192;
         let num_centroids = 64;

--- a/src/kmeans/matrix.rs
+++ b/src/kmeans/matrix.rs
@@ -15,8 +15,11 @@ const MATRIX_ASSIGNMENT_THRESHOLD: usize = 1 << 19;
 const SMALL_DIM_MATRIX_ASSIGNMENT_THRESHOLD: usize = 1 << 22;
 // Bound the reusable score matrix to 128 MiB.
 const MAX_MATRIX_ASSIGNMENT_ELEMENTS: usize = (128 << 20) / size_of::<f32>();
-// Additional engineering margin for the norm, dot-product, and final addition errors.
+// Additional engineering margins on top of using `f32::EPSILON`, which is already twice
+// Higham's unit roundoff. L2 needs more margin because it also adds two computed norms and can
+// suffer cancellation; dot-product scores only contain the reduction error.
 const L2_ERROR_BOUND_SAFETY_FACTOR: f32 = 8.0;
+const DOT_ERROR_BOUND_SAFETY_FACTOR: f32 = 1.0;
 
 pub(super) struct MatrixAssignmentWorkspace {
     distance: Distance,
@@ -46,21 +49,14 @@ impl MatrixAssignmentWorkspace {
             return None;
         }
 
-        let vector_norms = if distance == Distance::SquaredEuclidean {
-            vecs.par_chunks_exact(dim)
-                .map(|vector| vector.iter().map(|value| value * value).sum())
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let vector_norms = vecs
+            .par_chunks_exact(dim)
+            .map(|vector| vector.iter().map(|value| value * value).sum())
+            .collect();
         Some(Self {
             distance,
             vector_norms,
-            centroid_norms: if distance == Distance::SquaredEuclidean {
-                vec![0.0; num_centroids]
-            } else {
-                Vec::new()
-            },
+            centroid_norms: vec![0.0; num_centroids],
             dot_products: vec![0.0; comparison_count],
         })
     }
@@ -73,10 +69,8 @@ impl MatrixAssignmentWorkspace {
         labels: &mut [u32],
     ) {
         let num_centroids = centroids.len() / dim;
-        if self.distance == Distance::SquaredEuclidean {
-            debug_assert_eq!(self.vector_norms.len(), vecs.len() / dim);
-            debug_assert_eq!(self.centroid_norms.len(), num_centroids);
-        }
+        debug_assert_eq!(self.vector_norms.len(), vecs.len() / dim);
+        debug_assert_eq!(self.centroid_norms.len(), num_centroids);
         debug_assert_eq!(self.dot_products.len(), labels.len() * num_centroids);
 
         // Process 256 input rows per GEMM task; tuned on Apple Silicon with
@@ -105,24 +99,6 @@ impl MatrixAssignmentWorkspace {
                 );
             });
 
-        if self.distance == Distance::NegativeDotProduct {
-            labels
-                .par_iter_mut()
-                .zip(self.dot_products.par_chunks_exact(num_centroids))
-                .for_each(|(label, scores)| {
-                    let mut best_score = f32::MAX;
-                    let mut best_index = 0;
-                    for (index, &score) in scores.iter().enumerate() {
-                        if score < best_score {
-                            best_score = score;
-                            best_index = index;
-                        }
-                    }
-                    *label = best_index as u32;
-                });
-            return;
-        }
-
         self.centroid_norms
             .par_iter_mut()
             .zip(centroids.par_chunks_exact(dim))
@@ -136,6 +112,52 @@ impl MatrixAssignmentWorkspace {
         // so using it here is already conservative.
         let dimension_error = dim as f32 * f32::EPSILON;
         let gamma = dimension_error / (1.0 - dimension_error);
+
+        if self.distance == Distance::NegativeDotProduct {
+            let max_centroid_norm = max_centroid_norm.sqrt();
+            labels
+                .par_iter_mut()
+                .zip(&self.vector_norms)
+                .zip(vecs.par_chunks_exact(dim))
+                .zip(self.dot_products.par_chunks_exact(num_centroids))
+                .for_each(|(((label, &vector_norm), vector), scores)| {
+                    let mut best_score = f32::MAX;
+                    let mut second_best_score = f32::MAX;
+                    let mut best_index = 0;
+                    for (index, &score) in scores.iter().enumerate() {
+                        if score < best_score {
+                            second_best_score = best_score;
+                            best_score = score;
+                            best_index = index;
+                        } else if score < second_best_score {
+                            second_best_score = score;
+                        }
+                    }
+
+                    // Cauchy-Schwarz bounds the magnitude of the exact dot product by
+                    // ||x||₂ ||c||₂. Scores whose error intervals overlap are recomputed
+                    // with the direct implementation to preserve its assignment semantics.
+                    let uncertainty = DOT_ERROR_BOUND_SAFETY_FACTOR
+                        * gamma
+                        * vector_norm.sqrt()
+                        * max_centroid_norm;
+                    let ambiguity = 2.0 * uncertainty;
+                    if !best_score.is_finite() || second_best_score - best_score <= ambiguity {
+                        let mut exact_label = [0];
+                        base_assign(
+                            vector,
+                            centroids,
+                            dim,
+                            Distance::NegativeDotProduct,
+                            &mut exact_label,
+                        );
+                        *label = exact_label[0];
+                    } else {
+                        *label = best_index as u32;
+                    }
+                });
+            return;
+        }
 
         labels
             .par_iter_mut()
@@ -211,6 +233,7 @@ mod tests {
     use super::MatrixAssignmentWorkspace;
     use crate::distance::Distance;
     use crate::kmeans::base_assign;
+    use crate::utils::normalize;
 
     fn random_test_rng() -> StdRng {
         let seed = rand::rng().random();
@@ -264,6 +287,55 @@ mod tests {
         let centroids = (0..num_centroids * dim)
             .map(|_| rng.random::<f32>())
             .collect::<Vec<_>>();
+        let mut expected = vec![0; num_vectors];
+        let mut actual = vec![0; num_vectors];
+
+        base_assign(
+            &vecs,
+            &centroids,
+            dim,
+            Distance::NegativeDotProduct,
+            &mut expected,
+        );
+        let mut workspace = MatrixAssignmentWorkspace::try_new(
+            &vecs,
+            num_centroids,
+            dim,
+            Distance::NegativeDotProduct,
+        )
+        .unwrap();
+        workspace.assign(&vecs, &centroids, dim, &mut actual);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_matrix_dot_product_falls_back_for_near_ties() {
+        let mut rng = StdRng::seed_from_u64(7);
+        let dim = 64;
+        let num_vectors = 8192;
+        let num_centroids = 64;
+        let mut direction = (0..dim)
+            .map(|_| rng.random::<f32>() * 2.0 - 1.0)
+            .collect::<Vec<_>>();
+        normalize(&mut direction);
+        let mut centroids = Vec::with_capacity(num_centroids * dim);
+        for _ in 0..num_centroids {
+            let mut centroid = direction.clone();
+            centroid.iter_mut().for_each(|value| {
+                *value += (rng.random::<f32>() * 2.0 - 1.0) * 1e-6;
+            });
+            normalize(&mut centroid);
+            centroids.extend(centroid);
+        }
+        let mut vecs = Vec::with_capacity(num_vectors * dim);
+        for _ in 0..num_vectors {
+            let mut vector = (0..dim)
+                .map(|_| rng.random::<f32>() * 2.0 - 1.0)
+                .collect::<Vec<_>>();
+            normalize(&mut vector);
+            vecs.extend(vector);
+        }
         let mut expected = vec![0; num_vectors];
         let mut actual = vec![0; num_vectors];
 

--- a/src/kmeans/matrix.rs
+++ b/src/kmeans/matrix.rs
@@ -23,6 +23,7 @@ const MATMUL_BLOCK_SIZE: usize = 256;
 // suffer cancellation; dot-product scores only contain the reduction error.
 const L2_ERROR_BOUND_SAFETY_FACTOR: f32 = 8.0;
 const DOT_ERROR_BOUND_SAFETY_FACTOR: f32 = 1.0;
+const MIN_SUBNORMAL: f32 = f32::from_bits(1);
 
 fn try_zeroed(len: usize) -> Option<Vec<f32>> {
     let mut values = Vec::new();
@@ -126,6 +127,9 @@ impl MatrixAssignmentWorkspace {
         // so using it here is already conservative.
         let dimension_error = dim as f32 * f32::EPSILON;
         let gamma = dimension_error / (1.0 - dimension_error);
+        // The relative gamma_n model excludes underflow. Allow one minimum-subnormal rounding
+        // unit per reduction term so tiny, finite inputs still trigger the ambiguity fallback.
+        let underflow_error = dim as f32 * MIN_SUBNORMAL;
 
         if self.distance == Distance::NegativeDotProduct {
             let max_centroid_norm = max_centroid_norm.sqrt();
@@ -152,9 +156,7 @@ impl MatrixAssignmentWorkspace {
                     // ||x||₂ ||c||₂. Scores whose error intervals overlap are recomputed
                     // with the direct implementation to preserve its assignment semantics.
                     let uncertainty = DOT_ERROR_BOUND_SAFETY_FACTOR
-                        * gamma
-                        * vector_norm.sqrt()
-                        * max_centroid_norm;
+                        * (gamma * vector_norm.sqrt() * max_centroid_norm + underflow_error);
                     let ambiguity = 2.0 * uncertainty;
                     if !centroid_norms_are_finite
                         || !vector_norm.is_finite()
@@ -203,8 +205,7 @@ impl MatrixAssignmentWorkspace {
                 // The norm identity can suffer cancellation. The safety factor is an
                 // engineering margin, not part of Higham's gamma_n bound.
                 let uncertainty = L2_ERROR_BOUND_SAFETY_FACTOR
-                    * gamma
-                    * (vector_norm.abs() + max_centroid_norm.abs());
+                    * (gamma * (vector_norm.abs() + max_centroid_norm.abs()) + underflow_error);
                 // Two estimates can each err in opposite directions by `uncertainty`.
                 let ambiguity = 2.0 * uncertainty;
                 if !centroid_norms_are_finite
@@ -328,6 +329,34 @@ mod tests {
     }
 
     #[test]
+    fn test_matrix_assignment_reuses_workspace_with_updated_centroids() {
+        let mut rng = random_test_rng();
+        let dim = 64;
+        let num_vectors = 8192;
+        let num_centroids = 64;
+        let vecs = (0..num_vectors * dim)
+            .map(|_| rng.random::<f32>())
+            .collect::<Vec<_>>();
+
+        for distance in [Distance::SquaredEuclidean, Distance::NegativeDotProduct] {
+            let mut centroids = (0..num_centroids * dim)
+                .map(|_| rng.random::<f32>())
+                .collect::<Vec<_>>();
+            let mut actual = vec![0; num_vectors];
+            let mut workspace =
+                MatrixAssignmentWorkspace::try_new(&vecs, num_centroids, dim, distance).unwrap();
+            workspace.assign(&vecs, &centroids, dim, &mut actual);
+
+            centroids.iter_mut().for_each(|value| *value = 1.0 - *value);
+            let mut expected = vec![0; num_vectors];
+            base_assign(&vecs, &centroids, dim, distance, &mut expected);
+            workspace.assign(&vecs, &centroids, dim, &mut actual);
+
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
     fn test_matrix_dot_product_falls_back_for_near_ties() {
         let mut rng = StdRng::seed_from_u64(7);
         let dim = 64;
@@ -434,5 +463,47 @@ mod tests {
         for (index, &label) in labels.iter().enumerate() {
             assert_eq!(label as usize, index % num_centroids);
         }
+    }
+
+    #[test]
+    fn test_matrix_dot_product_handles_subnormal_scores() {
+        let dim = 64;
+        let num_vectors = 8192;
+        let num_centroids = 64;
+        let tiny = f32::from_bits(1).sqrt();
+        let mut centroids = Vec::with_capacity(num_centroids * dim);
+        for index in 0..num_centroids {
+            centroids.extend((0..dim).map(|coordinate| {
+                if index & (1 << (coordinate % 6)) == 0 {
+                    tiny
+                } else {
+                    -tiny
+                }
+            }));
+        }
+        let mut vecs = Vec::with_capacity(num_vectors * dim);
+        for index in 0..num_vectors {
+            vecs.extend_from_slice(&centroids[(index % num_centroids) * dim..][..dim]);
+        }
+        let mut expected = vec![0; num_vectors];
+        let mut actual = vec![0; num_vectors];
+
+        base_assign(
+            &vecs,
+            &centroids,
+            dim,
+            Distance::NegativeDotProduct,
+            &mut expected,
+        );
+        let mut workspace = MatrixAssignmentWorkspace::try_new(
+            &vecs,
+            num_centroids,
+            dim,
+            Distance::NegativeDotProduct,
+        )
+        .unwrap();
+        workspace.assign(&vecs, &centroids, dim, &mut actual);
+
+        assert_eq!(actual, expected);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,24 +29,3 @@ pub mod rabitq;
 pub mod sampling;
 pub mod simd;
 pub mod utils;
-
-#[cfg(test)]
-pub(crate) mod test_utils {
-    use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
-
-    const TEST_SEED_ENV: &str = "GATHERS_TEST_SEED";
-
-    pub(crate) fn random_test_rng() -> StdRng {
-        let seed = std::env::var(TEST_SEED_ENV).map_or_else(
-            |_| rand::rng().random(),
-            |value| {
-                value.parse().unwrap_or_else(|_| {
-                    panic!("{TEST_SEED_ENV} must be an unsigned 64-bit integer")
-                })
-            },
-        );
-        eprintln!("random seed: {seed}; reproduce with {TEST_SEED_ENV}={seed}");
-        StdRng::seed_from_u64(seed)
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,3 +29,24 @@ pub mod rabitq;
 pub mod sampling;
 pub mod simd;
 pub mod utils;
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    const TEST_SEED_ENV: &str = "GATHERS_TEST_SEED";
+
+    pub(crate) fn random_test_rng() -> StdRng {
+        let seed = std::env::var(TEST_SEED_ENV).map_or_else(
+            |_| rand::rng().random(),
+            |value| {
+                value.parse().unwrap_or_else(|_| {
+                    panic!("{TEST_SEED_ENV} must be an unsigned 64-bit integer")
+                })
+            },
+        );
+        eprintln!("random seed: {seed}; reproduce with {TEST_SEED_ENV}={seed}");
+        StdRng::seed_from_u64(seed)
+    }
+}

--- a/src/rabitq.rs
+++ b/src/rabitq.rs
@@ -567,6 +567,7 @@ impl RaBitQ {
 #[cfg(test)]
 mod test {
     use rand::Rng;
+    use seed_rand::seeded_rng;
 
     use super::{RaBitQ, min_max_residual, min_max_residual_native};
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
@@ -577,7 +578,6 @@ mod test {
     use crate::distance::squared_euclidean;
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     use crate::simd;
-    use seed_rand::seeded_rng;
 
     #[test]
     #[should_panic(expected = "centroids must be complete")]

--- a/src/rabitq.rs
+++ b/src/rabitq.rs
@@ -566,7 +566,8 @@ impl RaBitQ {
 
 #[cfg(test)]
 mod test {
-    use rand::Rng;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
 
     use super::{RaBitQ, min_max_residual, min_max_residual_native};
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
@@ -577,6 +578,12 @@ mod test {
     use crate::distance::squared_euclidean;
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     use crate::simd;
+
+    fn random_test_rng() -> StdRng {
+        let seed = rand::rng().random();
+        eprintln!("random seed: {seed}");
+        StdRng::seed_from_u64(seed)
+    }
 
     #[test]
     #[should_panic(expected = "centroids must be complete")]
@@ -590,7 +597,7 @@ mod test {
         if !crate::simd::Avx2::is_available() {
             return;
         }
-        let mut rng = rand::rng();
+        let mut rng = random_test_rng();
 
         for _ in 0..100 {
             for dim in [1, 2, 4, 8, 10].into_iter() {
@@ -614,7 +621,7 @@ mod test {
         if !crate::simd::Avx2::is_available() {
             return;
         }
-        let mut rng = rand::rng();
+        let mut rng = random_test_rng();
 
         for _ in 0..100 {
             for dim in [64, 128, 256, 320, 1024].into_iter() {
@@ -634,7 +641,7 @@ mod test {
         if !crate::simd::Avx2::is_available() {
             return;
         }
-        let mut rng = rand::rng();
+        let mut rng = random_test_rng();
         for _ in 0..100 {
             for dim in [64, 128, 256, 320, 1024].into_iter() {
                 let x = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();
@@ -656,7 +663,7 @@ mod test {
 
     #[test]
     fn test_min_max_residual() {
-        let mut rng = rand::rng();
+        let mut rng = random_test_rng();
         for _ in 0..100 {
             for dim in [32, 64, 124, 128, 132].into_iter() {
                 let x = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();
@@ -690,7 +697,7 @@ mod test {
 
     #[test]
     fn test_batch_retrieval_matches_individual_retrieval() {
-        let mut rng = rand::rng();
+        let mut rng = random_test_rng();
         let dim = 64;
         let centroids = (0..16 * dim)
             .map(|_| rng.random::<f32>())

--- a/src/rabitq.rs
+++ b/src/rabitq.rs
@@ -566,8 +566,7 @@ impl RaBitQ {
 
 #[cfg(test)]
 mod test {
-    use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::Rng;
 
     use super::{RaBitQ, min_max_residual, min_max_residual_native};
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
@@ -578,12 +577,7 @@ mod test {
     use crate::distance::squared_euclidean;
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     use crate::simd;
-
-    fn random_test_rng() -> StdRng {
-        let seed = rand::rng().random();
-        eprintln!("random seed: {seed}");
-        StdRng::seed_from_u64(seed)
-    }
+    use crate::test_utils::random_test_rng;
 
     #[test]
     #[should_panic(expected = "centroids must be complete")]

--- a/src/rabitq.rs
+++ b/src/rabitq.rs
@@ -577,7 +577,7 @@ mod test {
     use crate::distance::squared_euclidean;
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     use crate::simd;
-    use crate::test_utils::random_test_rng;
+    use seed_rand::seeded_rng;
 
     #[test]
     #[should_panic(expected = "centroids must be complete")]
@@ -591,7 +591,7 @@ mod test {
         if !crate::simd::Avx2::is_available() {
             return;
         }
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
 
         for _ in 0..100 {
             for dim in [1, 2, 4, 8, 10].into_iter() {
@@ -615,7 +615,7 @@ mod test {
         if !crate::simd::Avx2::is_available() {
             return;
         }
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
 
         for _ in 0..100 {
             for dim in [64, 128, 256, 320, 1024].into_iter() {
@@ -635,7 +635,7 @@ mod test {
         if !crate::simd::Avx2::is_available() {
             return;
         }
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
         for _ in 0..100 {
             for dim in [64, 128, 256, 320, 1024].into_iter() {
                 let x = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();
@@ -657,7 +657,7 @@ mod test {
 
     #[test]
     fn test_min_max_residual() {
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
         for _ in 0..100 {
             for dim in [32, 64, 124, 128, 132].into_iter() {
                 let x = (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>();
@@ -691,7 +691,7 @@ mod test {
 
     #[test]
     fn test_batch_retrieval_matches_individual_retrieval() {
-        let mut rng = random_test_rng();
+        let mut rng = seeded_rng();
         let dim = 64;
         let centroids = (0..16 * dim)
             .map(|_| rng.random::<f32>())

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -5,7 +5,21 @@ use rand::Rng;
 
 /// Subsample a given number of vectors from a list of vectors.
 pub fn subsample(n_sample: usize, vecs: &[f32], dim: usize) -> Vec<Vec<f32>> {
-    reservoir_sampling(n_sample, &mut vecs.chunks(dim).map(|chunk| chunk.to_vec()))
+    let mut rng = rand::rng();
+    subsample_inner(n_sample, vecs, dim, &mut rng)
+}
+
+pub(crate) fn subsample_inner<R: Rng + ?Sized>(
+    n_sample: usize,
+    vecs: &[f32],
+    dim: usize,
+    rng: &mut R,
+) -> Vec<Vec<f32>> {
+    reservoir_sampling_inner(
+        n_sample,
+        &mut vecs.chunks(dim).map(|chunk| chunk.to_vec()),
+        rng,
+    )
 }
 
 /// Reservoir sampling algorithm.
@@ -16,9 +30,17 @@ where
     I: Iterator<Item = Vec<T>>,
     T: Num + Copy,
 {
-    let mut res = Vec::with_capacity(n_sample);
     let mut rng = rand::rng();
+    reservoir_sampling_inner(n_sample, iteration, &mut rng)
+}
 
+fn reservoir_sampling_inner<I, T, R>(n_sample: usize, iteration: &mut I, rng: &mut R) -> Vec<Vec<T>>
+where
+    I: Iterator<Item = Vec<T>>,
+    T: Num + Copy,
+    R: Rng + ?Sized,
+{
+    let mut res = Vec::with_capacity(n_sample);
     for _ in 0..n_sample {
         res.push(iteration.next().expect("iteration less than n_sample"));
     }


### PR DESCRIPTION
The code changed a lot so take from #35 to this new PR.

Make this `faer` matrix workspace available on all platform. Need to tune the threshold later.

cc @yihong0618